### PR TITLE
Simplify input handling

### DIFF
--- a/Billboard/game.ts
+++ b/Billboard/game.ts
@@ -17,19 +17,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -41,8 +28,8 @@ export class Game {
     public CanvasBillboard = document.querySelector("canvas#billboard")! as HTMLCanvasElement;
     public GL: WebGL2RenderingContext;
     public Context2D: CanvasRenderingContext2D;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
+    public InputState: Record<string, number> = {};
+    public InputEvent: Record<string, number> = {};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -55,26 +42,32 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
+        window.addEventListener("keydown", evt => {
+            this.InputState[evt.code] = 1;
+            this.InputEvent[evt.code] = 1;
+        });
+        window.addEventListener("keyup", evt => {
+            this.InputState[evt.code] = 0;
+            this.InputEvent[evt.code] = -1;
+        });
         this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 1;
+            this.InputEvent[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 0;
+            this.InputEvent[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
+            this.InputState.MouseX = evt.offsetX;
+            this.InputState.MouseY = evt.offsetY;
+            this.InputEvent.MouseX = evt.movementX;
+            this.InputEvent.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
+            this.InputEvent.WheelY = evt.deltaY;
         });
+        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
 
         this.GL = this.CanvasScene.getContext("webgl2")!;
@@ -89,7 +82,6 @@ export class Game {
     }
 
     FrameReset() {
-        // Reset event flags for the next frame.
         this.ViewportResized = false;
         for (let name in this.InputEvent) {
             this.InputEvent[name] = 0;

--- a/Billboard/game.ts
+++ b/Billboard/game.ts
@@ -43,8 +43,10 @@ export class Game {
         );
 
         window.addEventListener("keydown", evt => {
-            this.InputState[evt.code] = 1;
-            this.InputEvent[evt.code] = 1;
+            if (!evt.repeat) {
+                this.InputState[evt.code] = 1;
+                this.InputEvent[evt.code] = 1;
+            }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;

--- a/Billboard/game.ts
+++ b/Billboard/game.ts
@@ -29,7 +29,7 @@ export class Game {
     public GL: WebGL2RenderingContext;
     public Context2D: CanvasRenderingContext2D;
     public InputState: Record<string, number> = {};
-    public InputEvent: Record<string, number> = {};
+    public InputDelta: Record<string, number> = {};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -45,29 +45,29 @@ export class Game {
         window.addEventListener("keydown", evt => {
             if (!evt.repeat) {
                 this.InputState[evt.code] = 1;
-                this.InputEvent[evt.code] = 1;
+                this.InputDelta[evt.code] = 1;
             }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;
-            this.InputEvent[evt.code] = -1;
+            this.InputDelta[evt.code] = -1;
         });
         this.UI.addEventListener("mousedown", evt => {
             this.InputState[`Mouse${evt.button}`] = 1;
-            this.InputEvent[`Mouse${evt.button}`] = 1;
+            this.InputDelta[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
             this.InputState[`Mouse${evt.button}`] = 0;
-            this.InputEvent[`Mouse${evt.button}`] = -1;
+            this.InputDelta[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
             this.InputState.MouseX = evt.offsetX;
             this.InputState.MouseY = evt.offsetY;
-            this.InputEvent.MouseX = evt.movementX;
-            this.InputEvent.MouseY = evt.movementY;
+            this.InputDelta.MouseX = evt.movementX;
+            this.InputDelta.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.WheelY = evt.deltaY;
+            this.InputDelta.WheelY = evt.deltaY;
         });
         this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
@@ -85,8 +85,8 @@ export class Game {
 
     FrameReset() {
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
+        for (let name in this.InputDelta) {
+            this.InputDelta[name] = 0;
         }
     }
 

--- a/Billboard/systems/sys_control_player.ts
+++ b/Billboard/systems/sys_control_player.ts
@@ -20,35 +20,35 @@ function update(game: Game, entity: Entity, delta: number) {
 
     if (control.Move) {
         let move = game.World.Move[entity];
-        if (game.InputState.KeyW) {
+        if (game.InputState["KeyW"]) {
             // Move forward
             move.Directions.push([0, 0, 1]);
         }
-        if (game.InputState.KeyA) {
+        if (game.InputState["KeyA"]) {
             // Strafe left
             move.Directions.push([1, 0, 0]);
         }
-        if (game.InputState.KeyS) {
+        if (game.InputState["KeyS"]) {
             // Move backward
             move.Directions.push([0, 0, -1]);
         }
-        if (game.InputState.KeyD) {
+        if (game.InputState["KeyD"]) {
             // Strafe right
             move.Directions.push([-1, 0, 0]);
         }
     }
 
-    if (control.Yaw) {
+    if (control.Yaw && game.InputEvent.MouseX) {
         let move = game.World.Move[entity];
-        let yaw_delta = game.InputEvent.mouse_x * move.RotateSpeed * delta;
+        let yaw_delta = game.InputEvent.MouseX * move.RotateSpeed * delta;
         if (yaw_delta !== 0) {
             move.Yaws.push(from_axis([0, 0, 0, 0], AXIS_Y, -yaw_delta));
         }
     }
 
-    if (control.Pitch) {
+    if (control.Pitch && game.InputEvent.MouseY) {
         let move = game.World.Move[entity];
-        let pitch_delta = game.InputEvent.mouse_y * move.RotateSpeed * delta;
+        let pitch_delta = game.InputEvent.MouseY * move.RotateSpeed * delta;
         if (pitch_delta !== 0) {
             move.Pitches.push(from_axis([0, 0, 0, 0], AXIS_X, pitch_delta));
         }

--- a/Billboard/systems/sys_control_player.ts
+++ b/Billboard/systems/sys_control_player.ts
@@ -38,17 +38,17 @@ function update(game: Game, entity: Entity, delta: number) {
         }
     }
 
-    if (control.Yaw && game.InputEvent.MouseX) {
+    if (control.Yaw && game.InputDelta.MouseX) {
         let move = game.World.Move[entity];
-        let yaw_delta = game.InputEvent.MouseX * move.RotateSpeed * delta;
+        let yaw_delta = game.InputDelta.MouseX * move.RotateSpeed * delta;
         if (yaw_delta !== 0) {
             move.Yaws.push(from_axis([0, 0, 0, 0], AXIS_Y, -yaw_delta));
         }
     }
 
-    if (control.Pitch && game.InputEvent.MouseY) {
+    if (control.Pitch && game.InputDelta.MouseY) {
         let move = game.World.Move[entity];
-        let pitch_delta = game.InputEvent.MouseY * move.RotateSpeed * delta;
+        let pitch_delta = game.InputDelta.MouseY * move.RotateSpeed * delta;
         if (pitch_delta !== 0) {
             move.Pitches.push(from_axis([0, 0, 0, 0], AXIS_X, pitch_delta));
         }

--- a/FlyCamera/game.ts
+++ b/FlyCamera/game.ts
@@ -16,19 +16,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -38,8 +25,8 @@ export class Game {
     public UI = document.querySelector("main")!;
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
+    public InputState: Record<string, number> = {};
+    public InputEvent: Record<string, number> = {};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -52,26 +39,32 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
+        window.addEventListener("keydown", evt => {
+            this.InputState[evt.code] = 1;
+            this.InputEvent[evt.code] = 1;
+        });
+        window.addEventListener("keyup", evt => {
+            this.InputState[evt.code] = 0;
+            this.InputEvent[evt.code] = -1;
+        });
         this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 1;
+            this.InputEvent[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 0;
+            this.InputEvent[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
+            this.InputState.MouseX = evt.offsetX;
+            this.InputState.MouseY = evt.offsetY;
+            this.InputEvent.MouseX = evt.movementX;
+            this.InputEvent.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
+            this.InputEvent.WheelY = evt.deltaY;
         });
+        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
 
         this.GL = this.Canvas.getContext("webgl2")!;
@@ -84,7 +77,6 @@ export class Game {
     }
 
     FrameReset() {
-        // Reset event flags for the next frame.
         this.ViewportResized = false;
         for (let name in this.InputEvent) {
             this.InputEvent[name] = 0;

--- a/FlyCamera/game.ts
+++ b/FlyCamera/game.ts
@@ -40,8 +40,10 @@ export class Game {
         );
 
         window.addEventListener("keydown", evt => {
-            this.InputState[evt.code] = 1;
-            this.InputEvent[evt.code] = 1;
+            if (!evt.repeat) {
+                this.InputState[evt.code] = 1;
+                this.InputEvent[evt.code] = 1;
+            }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;

--- a/FlyCamera/game.ts
+++ b/FlyCamera/game.ts
@@ -26,7 +26,7 @@ export class Game {
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
     public InputState: Record<string, number> = {};
-    public InputEvent: Record<string, number> = {};
+    public InputDelta: Record<string, number> = {};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -42,29 +42,29 @@ export class Game {
         window.addEventListener("keydown", evt => {
             if (!evt.repeat) {
                 this.InputState[evt.code] = 1;
-                this.InputEvent[evt.code] = 1;
+                this.InputDelta[evt.code] = 1;
             }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;
-            this.InputEvent[evt.code] = -1;
+            this.InputDelta[evt.code] = -1;
         });
         this.UI.addEventListener("mousedown", evt => {
             this.InputState[`Mouse${evt.button}`] = 1;
-            this.InputEvent[`Mouse${evt.button}`] = 1;
+            this.InputDelta[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
             this.InputState[`Mouse${evt.button}`] = 0;
-            this.InputEvent[`Mouse${evt.button}`] = -1;
+            this.InputDelta[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
             this.InputState.MouseX = evt.offsetX;
             this.InputState.MouseY = evt.offsetY;
-            this.InputEvent.MouseX = evt.movementX;
-            this.InputEvent.MouseY = evt.movementY;
+            this.InputDelta.MouseX = evt.movementX;
+            this.InputDelta.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.WheelY = evt.deltaY;
+            this.InputDelta.WheelY = evt.deltaY;
         });
         this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
@@ -80,8 +80,8 @@ export class Game {
 
     FrameReset() {
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
+        for (let name in this.InputDelta) {
+            this.InputDelta[name] = 0;
         }
     }
 

--- a/FlyCamera/systems/sys_control_player.ts
+++ b/FlyCamera/systems/sys_control_player.ts
@@ -20,35 +20,35 @@ function update(game: Game, entity: Entity, delta: number) {
 
     if (control.Move) {
         let move = game.World.Move[entity];
-        if (game.InputState.KeyW) {
+        if (game.InputState["KeyW"]) {
             // Move forward
             move.Directions.push([0, 0, 1]);
         }
-        if (game.InputState.KeyA) {
+        if (game.InputState["KeyA"]) {
             // Strafe left
             move.Directions.push([1, 0, 0]);
         }
-        if (game.InputState.KeyS) {
+        if (game.InputState["KeyS"]) {
             // Move backward
             move.Directions.push([0, 0, -1]);
         }
-        if (game.InputState.KeyD) {
+        if (game.InputState["KeyD"]) {
             // Strafe right
             move.Directions.push([-1, 0, 0]);
         }
     }
 
-    if (control.Yaw) {
+    if (control.Yaw && game.InputEvent.MouseX) {
         let move = game.World.Move[entity];
-        let yaw_delta = game.InputEvent.mouse_x * move.RotateSpeed * delta;
+        let yaw_delta = game.InputEvent.MouseX * move.RotateSpeed * delta;
         if (yaw_delta !== 0) {
             move.Yaws.push(from_axis([0, 0, 0, 0], AXIS_Y, -yaw_delta));
         }
     }
 
-    if (control.Pitch) {
+    if (control.Pitch && game.InputEvent.MouseY) {
         let move = game.World.Move[entity];
-        let pitch_delta = game.InputEvent.mouse_y * move.RotateSpeed * delta;
+        let pitch_delta = game.InputEvent.MouseY * move.RotateSpeed * delta;
         if (pitch_delta !== 0) {
             move.Pitches.push(from_axis([0, 0, 0, 0], AXIS_X, pitch_delta));
         }

--- a/FlyCamera/systems/sys_control_player.ts
+++ b/FlyCamera/systems/sys_control_player.ts
@@ -38,17 +38,17 @@ function update(game: Game, entity: Entity, delta: number) {
         }
     }
 
-    if (control.Yaw && game.InputEvent.MouseX) {
+    if (control.Yaw && game.InputDelta.MouseX) {
         let move = game.World.Move[entity];
-        let yaw_delta = game.InputEvent.MouseX * move.RotateSpeed * delta;
+        let yaw_delta = game.InputDelta.MouseX * move.RotateSpeed * delta;
         if (yaw_delta !== 0) {
             move.Yaws.push(from_axis([0, 0, 0, 0], AXIS_Y, -yaw_delta));
         }
     }
 
-    if (control.Pitch && game.InputEvent.MouseY) {
+    if (control.Pitch && game.InputDelta.MouseY) {
         let move = game.World.Move[entity];
-        let pitch_delta = game.InputEvent.MouseY * move.RotateSpeed * delta;
+        let pitch_delta = game.InputDelta.MouseY * move.RotateSpeed * delta;
         if (pitch_delta !== 0) {
             move.Pitches.push(from_axis([0, 0, 0, 0], AXIS_X, pitch_delta));
         }

--- a/Instancing/game.ts
+++ b/Instancing/game.ts
@@ -14,19 +14,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -36,8 +23,6 @@ export class Game {
     public UI = document.querySelector("main")!;
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
 
     public MaterialInstanced: Material;
     public MeshCube: Mesh;
@@ -50,28 +35,6 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
-        this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
-        });
-        this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
-        });
-        this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
-        });
-        this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
-        });
-        this.UI.addEventListener("click", () => this.UI.requestPointerLock());
-
         this.GL = this.Canvas.getContext("webgl2")!;
         this.GL.enable(GL_DEPTH_TEST);
         this.GL.enable(GL_CULL_FACE);
@@ -82,11 +45,7 @@ export class Game {
     }
 
     FrameReset() {
-        // Reset event flags for the next frame.
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
-        }
     }
 
     FrameUpdate(delta: number) {

--- a/Monkey/game.ts
+++ b/Monkey/game.ts
@@ -16,19 +16,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -38,8 +25,6 @@ export class Game {
     public UI = document.querySelector("main")!;
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
 
     public MaterialFlat: Material;
     public MaterialPhong: Material;
@@ -54,28 +39,6 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
-        this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
-        });
-        this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
-        });
-        this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
-        });
-        this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
-        });
-        this.UI.addEventListener("click", () => this.UI.requestPointerLock());
-
         this.GL = this.Canvas.getContext("webgl2")!;
         this.GL.enable(GL_DEPTH_TEST);
         this.GL.enable(GL_CULL_FACE);
@@ -88,11 +51,7 @@ export class Game {
     }
 
     FrameReset() {
-        // Reset event flags for the next frame.
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
-        }
     }
 
     FrameUpdate(delta: number) {

--- a/NewProject2D/core.ts
+++ b/NewProject2D/core.ts
@@ -13,13 +13,8 @@ export function start(game: Game) {
 
     let tick = (now: number) => {
         let delta = (now - last) / 1000;
-        game.Update(delta);
-
-        // Reset all input events for the next frame.
-        for (let name in game.InputDelta) {
-            game.InputDelta[name] = 0;
-        }
-
+        game.FrameUpdate(delta);
+        game.FrameReset();
         last = now;
         raf = requestAnimationFrame(tick);
     };

--- a/NewProject2D/core.ts
+++ b/NewProject2D/core.ts
@@ -16,8 +16,8 @@ export function start(game: Game) {
         game.Update(delta);
 
         // Reset all input events for the next frame.
-        for (let name in game.InputEvent) {
-            game.InputEvent[name] = 0;
+        for (let name in game.InputDelta) {
+            game.InputDelta[name] = 0;
         }
 
         last = now;

--- a/NewProject2D/game.ts
+++ b/NewProject2D/game.ts
@@ -21,8 +21,10 @@ export class Game {
         );
 
         window.addEventListener("keydown", evt => {
-            this.InputState[evt.code] = 1;
-            this.InputEvent[evt.code] = 1;
+            if (!evt.repeat) {
+                this.InputState[evt.code] = 1;
+                this.InputEvent[evt.code] = 1;
+            }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;

--- a/NewProject2D/game.ts
+++ b/NewProject2D/game.ts
@@ -6,53 +6,46 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     World = new World();
     ViewportWidth = window.innerWidth;
     ViewportHeight = window.innerHeight;
     Context2D: CanvasRenderingContext2D;
     UI = document.querySelector("main")!;
-    InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
+    InputState: Record<string, number> = {};
+    InputEvent: Record<string, number> = {};
 
     constructor() {
         document.addEventListener("visibilitychange", () =>
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
+        window.addEventListener("keydown", evt => {
+            this.InputState[evt.code] = 1;
+            this.InputEvent[evt.code] = 1;
+        });
+        window.addEventListener("keyup", evt => {
+            this.InputState[evt.code] = 0;
+            this.InputEvent[evt.code] = -1;
+        });
         this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 1;
+            this.InputEvent[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 0;
+            this.InputEvent[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
+            this.InputState.MouseX = evt.offsetX;
+            this.InputState.MouseY = evt.offsetY;
+            this.InputEvent.MouseX = evt.movementX;
+            this.InputEvent.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
+            this.InputEvent.WheelY = evt.deltaY;
         });
+        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
 
         let canvas2d = document.querySelector("canvas")!;

--- a/NewProject2D/game.ts
+++ b/NewProject2D/game.ts
@@ -56,7 +56,13 @@ export class Game {
         this.Context2D = canvas2d.getContext("2d")!;
     }
 
-    Update(delta: number) {
+    FrameReset() {
+        for (let name in this.InputDelta) {
+            this.InputDelta[name] = 0;
+        }
+    }
+
+    FrameUpdate(delta: number) {
         let now = performance.now();
         sys_transform2d(this, delta);
         sys_draw2d(this, delta);

--- a/NewProject2D/game.ts
+++ b/NewProject2D/game.ts
@@ -13,7 +13,7 @@ export class Game {
     Context2D: CanvasRenderingContext2D;
     UI = document.querySelector("main")!;
     InputState: Record<string, number> = {};
-    InputEvent: Record<string, number> = {};
+    InputDelta: Record<string, number> = {};
 
     constructor() {
         document.addEventListener("visibilitychange", () =>
@@ -23,29 +23,29 @@ export class Game {
         window.addEventListener("keydown", evt => {
             if (!evt.repeat) {
                 this.InputState[evt.code] = 1;
-                this.InputEvent[evt.code] = 1;
+                this.InputDelta[evt.code] = 1;
             }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;
-            this.InputEvent[evt.code] = -1;
+            this.InputDelta[evt.code] = -1;
         });
         this.UI.addEventListener("mousedown", evt => {
             this.InputState[`Mouse${evt.button}`] = 1;
-            this.InputEvent[`Mouse${evt.button}`] = 1;
+            this.InputDelta[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
             this.InputState[`Mouse${evt.button}`] = 0;
-            this.InputEvent[`Mouse${evt.button}`] = -1;
+            this.InputDelta[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
             this.InputState.MouseX = evt.offsetX;
             this.InputState.MouseY = evt.offsetY;
-            this.InputEvent.MouseX = evt.movementX;
-            this.InputEvent.MouseY = evt.movementY;
+            this.InputDelta.MouseX = evt.movementX;
+            this.InputDelta.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.WheelY = evt.deltaY;
+            this.InputDelta.WheelY = evt.deltaY;
         });
         this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());

--- a/NewProject3D/game.ts
+++ b/NewProject3D/game.ts
@@ -38,8 +38,10 @@ export class Game {
         );
 
         window.addEventListener("keydown", evt => {
-            this.InputState[evt.code] = 1;
-            this.InputEvent[evt.code] = 1;
+            if (!evt.repeat) {
+                this.InputState[evt.code] = 1;
+                this.InputEvent[evt.code] = 1;
+            }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;

--- a/NewProject3D/game.ts
+++ b/NewProject3D/game.ts
@@ -14,19 +14,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -36,8 +23,8 @@ export class Game {
     public UI = document.querySelector("main")!;
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
+    public InputState: Record<string, number> = {};
+    public InputEvent: Record<string, number> = {};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -50,26 +37,32 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
+        window.addEventListener("keydown", evt => {
+            this.InputState[evt.code] = 1;
+            this.InputEvent[evt.code] = 1;
+        });
+        window.addEventListener("keyup", evt => {
+            this.InputState[evt.code] = 0;
+            this.InputEvent[evt.code] = -1;
+        });
         this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 1;
+            this.InputEvent[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 0;
+            this.InputEvent[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
+            this.InputState.MouseX = evt.offsetX;
+            this.InputState.MouseY = evt.offsetY;
+            this.InputEvent.MouseX = evt.movementX;
+            this.InputEvent.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
+            this.InputEvent.WheelY = evt.deltaY;
         });
+        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
 
         this.GL = this.Canvas.getContext("webgl2")!;

--- a/NewProject3D/game.ts
+++ b/NewProject3D/game.ts
@@ -24,7 +24,7 @@ export class Game {
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
     public InputState: Record<string, number> = {};
-    public InputEvent: Record<string, number> = {};
+    public InputDelta: Record<string, number> = {};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -40,29 +40,29 @@ export class Game {
         window.addEventListener("keydown", evt => {
             if (!evt.repeat) {
                 this.InputState[evt.code] = 1;
-                this.InputEvent[evt.code] = 1;
+                this.InputDelta[evt.code] = 1;
             }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;
-            this.InputEvent[evt.code] = -1;
+            this.InputDelta[evt.code] = -1;
         });
         this.UI.addEventListener("mousedown", evt => {
             this.InputState[`Mouse${evt.button}`] = 1;
-            this.InputEvent[`Mouse${evt.button}`] = 1;
+            this.InputDelta[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
             this.InputState[`Mouse${evt.button}`] = 0;
-            this.InputEvent[`Mouse${evt.button}`] = -1;
+            this.InputDelta[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
             this.InputState.MouseX = evt.offsetX;
             this.InputState.MouseY = evt.offsetY;
-            this.InputEvent.MouseX = evt.movementX;
-            this.InputEvent.MouseY = evt.movementY;
+            this.InputDelta.MouseX = evt.movementX;
+            this.InputDelta.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.WheelY = evt.deltaY;
+            this.InputDelta.WheelY = evt.deltaY;
         });
         this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
@@ -79,8 +79,8 @@ export class Game {
     FrameReset() {
         // Reset event flags for the next frame.
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
+        for (let name in this.InputDelta) {
+            this.InputDelta[name] = 0;
         }
     }
 

--- a/Particles/game.ts
+++ b/Particles/game.ts
@@ -13,19 +13,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -35,8 +22,6 @@ export class Game {
     public UI = document.querySelector("main")!;
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
 
     public MaterialParticles: Material;
 
@@ -47,28 +32,6 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
-        this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
-        });
-        this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
-        });
-        this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
-        });
-        this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
-        });
-        this.UI.addEventListener("click", () => this.UI.requestPointerLock());
-
         this.GL = this.Canvas.getContext("webgl2")!;
         this.GL.enable(GL_DEPTH_TEST);
         this.GL.enable(GL_CULL_FACE);
@@ -78,11 +41,7 @@ export class Game {
     }
 
     FrameReset() {
-        // Reset event flags for the next frame.
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
-        }
     }
 
     FrameUpdate(delta: number) {

--- a/RigidBody/game.ts
+++ b/RigidBody/game.ts
@@ -18,19 +18,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -40,8 +27,6 @@ export class Game {
     public UI = document.querySelector("main")!;
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -54,28 +39,6 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
-        this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
-        });
-        this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
-        });
-        this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
-        });
-        this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
-        });
-        this.UI.addEventListener("click", () => this.UI.requestPointerLock());
-
         this.GL = this.Canvas.getContext("webgl2")!;
         this.GL.enable(GL_DEPTH_TEST);
         this.GL.enable(GL_CULL_FACE);
@@ -86,11 +49,7 @@ export class Game {
     }
 
     FrameReset() {
-        // Reset event flags for the next frame.
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
-        }
     }
 
     FrameUpdate(delta: number) {

--- a/Shading/game.ts
+++ b/Shading/game.ts
@@ -21,19 +21,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -43,8 +30,6 @@ export class Game {
     public UI = document.querySelector("main")!;
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
 
     public MaterialPoints: Material;
     public MaterialWireframe: Material;
@@ -65,28 +50,6 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
-        this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
-        });
-        this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
-        });
-        this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
-        });
-        this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
-        });
-        this.UI.addEventListener("click", () => this.UI.requestPointerLock());
-
         this.GL = this.Canvas.getContext("webgl2")!;
         this.GL.enable(GL_DEPTH_TEST);
         this.GL.enable(GL_CULL_FACE);
@@ -105,11 +68,7 @@ export class Game {
     }
 
     FrameReset() {
-        // Reset event flags for the next frame.
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
-        }
     }
 
     FrameUpdate(delta: number) {

--- a/ThirdPerson/game.ts
+++ b/ThirdPerson/game.ts
@@ -43,8 +43,10 @@ export class Game {
         );
 
         window.addEventListener("keydown", evt => {
-            this.InputState[evt.code] = 1;
-            this.InputEvent[evt.code] = 1;
+            if (!evt.repeat) {
+                this.InputState[evt.code] = 1;
+                this.InputEvent[evt.code] = 1;
+            }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;

--- a/ThirdPerson/game.ts
+++ b/ThirdPerson/game.ts
@@ -29,7 +29,7 @@ export class Game {
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
     public InputState: Record<string, number> = {};
-    public InputEvent: Record<string, number> = {};
+    public InputDelta: Record<string, number> = {};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -45,29 +45,29 @@ export class Game {
         window.addEventListener("keydown", evt => {
             if (!evt.repeat) {
                 this.InputState[evt.code] = 1;
-                this.InputEvent[evt.code] = 1;
+                this.InputDelta[evt.code] = 1;
             }
         });
         window.addEventListener("keyup", evt => {
             this.InputState[evt.code] = 0;
-            this.InputEvent[evt.code] = -1;
+            this.InputDelta[evt.code] = -1;
         });
         this.UI.addEventListener("mousedown", evt => {
             this.InputState[`Mouse${evt.button}`] = 1;
-            this.InputEvent[`Mouse${evt.button}`] = 1;
+            this.InputDelta[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
             this.InputState[`Mouse${evt.button}`] = 0;
-            this.InputEvent[`Mouse${evt.button}`] = -1;
+            this.InputDelta[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
             this.InputState.MouseX = evt.offsetX;
             this.InputState.MouseY = evt.offsetY;
-            this.InputEvent.MouseX = evt.movementX;
-            this.InputEvent.MouseY = evt.movementY;
+            this.InputDelta.MouseX = evt.movementX;
+            this.InputDelta.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.WheelY = evt.deltaY;
+            this.InputDelta.WheelY = evt.deltaY;
         });
         this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
@@ -84,8 +84,8 @@ export class Game {
     FrameReset() {
         // Reset event flags for the next frame.
         this.ViewportResized = false;
-        for (let name in this.InputEvent) {
-            this.InputEvent[name] = 0;
+        for (let name in this.InputDelta) {
+            this.InputDelta[name] = 0;
         }
     }
 

--- a/ThirdPerson/game.ts
+++ b/ThirdPerson/game.ts
@@ -19,19 +19,6 @@ import {World} from "./world.js";
 
 export type Entity = number;
 
-export interface InputState {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-}
-
-export interface InputEvent {
-    [k: string]: number;
-    mouse_x: number;
-    mouse_y: number;
-    wheel_y: number;
-}
-
 export class Game {
     public World = new World();
 
@@ -41,8 +28,8 @@ export class Game {
     public UI = document.querySelector("main")!;
     public Canvas = document.querySelector("canvas")!;
     public GL: WebGL2RenderingContext;
-    public InputState: InputState = {mouse_x: 0, mouse_y: 0};
-    public InputEvent: InputEvent = {mouse_x: 0, mouse_y: 0, wheel_y: 0};
+    public InputState: Record<string, number> = {};
+    public InputEvent: Record<string, number> = {};
 
     public MaterialGouraud: Material;
     public MeshCube: Mesh;
@@ -55,26 +42,32 @@ export class Game {
             document.hidden ? stop() : start(this)
         );
 
-        window.addEventListener("keydown", evt => (this.InputState[evt.code] = 1));
-        window.addEventListener("keyup", evt => (this.InputState[evt.code] = 0));
-        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
+        window.addEventListener("keydown", evt => {
+            this.InputState[evt.code] = 1;
+            this.InputEvent[evt.code] = 1;
+        });
+        window.addEventListener("keyup", evt => {
+            this.InputState[evt.code] = 0;
+            this.InputEvent[evt.code] = -1;
+        });
         this.UI.addEventListener("mousedown", evt => {
-            this.InputState[`mouse_${evt.button}`] = 1;
-            this.InputEvent[`mouse_${evt.button}_down`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 1;
+            this.InputEvent[`Mouse${evt.button}`] = 1;
         });
         this.UI.addEventListener("mouseup", evt => {
-            this.InputState[`mouse_${evt.button}`] = 0;
-            this.InputEvent[`mouse_${evt.button}_up`] = 1;
+            this.InputState[`Mouse${evt.button}`] = 0;
+            this.InputEvent[`Mouse${evt.button}`] = -1;
         });
         this.UI.addEventListener("mousemove", evt => {
-            this.InputState.mouse_x = evt.offsetX;
-            this.InputState.mouse_y = evt.offsetY;
-            this.InputEvent.mouse_x = evt.movementX;
-            this.InputEvent.mouse_y = evt.movementY;
+            this.InputState.MouseX = evt.offsetX;
+            this.InputState.MouseY = evt.offsetY;
+            this.InputEvent.MouseX = evt.movementX;
+            this.InputEvent.MouseY = evt.movementY;
         });
         this.UI.addEventListener("wheel", evt => {
-            this.InputEvent.wheel_y = evt.deltaY;
+            this.InputEvent.WheelY = evt.deltaY;
         });
+        this.UI.addEventListener("contextmenu", evt => evt.preventDefault());
         this.UI.addEventListener("click", () => this.UI.requestPointerLock());
 
         this.GL = this.Canvas.getContext("webgl2")!;

--- a/ThirdPerson/systems/sys_control_player.ts
+++ b/ThirdPerson/systems/sys_control_player.ts
@@ -38,17 +38,17 @@ function update(game: Game, entity: Entity, delta: number) {
         }
     }
 
-    if (control.Yaw && game.InputEvent.MouseX) {
+    if (control.Yaw && game.InputDelta.MouseX) {
         let move = game.World.Move[entity];
-        let yaw_delta = game.InputEvent.MouseX * move.RotateSpeed * delta;
+        let yaw_delta = game.InputDelta.MouseX * move.RotateSpeed * delta;
         if (yaw_delta !== 0) {
             move.Yaws.push(from_axis([0, 0, 0, 0], AXIS_Y, -yaw_delta));
         }
     }
 
-    if (control.Pitch && game.InputEvent.MouseY) {
+    if (control.Pitch && game.InputDelta.MouseY) {
         let move = game.World.Move[entity];
-        let pitch_delta = game.InputEvent.MouseY * move.RotateSpeed * delta;
+        let pitch_delta = game.InputDelta.MouseY * move.RotateSpeed * delta;
         if (pitch_delta !== 0) {
             let new_pitch = control.CurrentPitch + pitch_delta;
             if (-0.2 < new_pitch && new_pitch < Math.PI / 2) {

--- a/ThirdPerson/systems/sys_control_player.ts
+++ b/ThirdPerson/systems/sys_control_player.ts
@@ -20,35 +20,35 @@ function update(game: Game, entity: Entity, delta: number) {
 
     if (control.Move) {
         let move = game.World.Move[entity];
-        if (game.InputState.KeyW) {
+        if (game.InputState["KeyW"]) {
             // Move forward
             move.Directions.push([0, 0, 1]);
         }
-        if (game.InputState.KeyA) {
+        if (game.InputState["KeyA"]) {
             // Strafe left
             move.Directions.push([1, 0, 0]);
         }
-        if (game.InputState.KeyS) {
+        if (game.InputState["KeyS"]) {
             // Move backward
             move.Directions.push([0, 0, -1]);
         }
-        if (game.InputState.KeyD) {
+        if (game.InputState["KeyD"]) {
             // Strafe right
             move.Directions.push([-1, 0, 0]);
         }
     }
 
-    if (control.Yaw) {
+    if (control.Yaw && game.InputEvent.MouseX) {
         let move = game.World.Move[entity];
-        let yaw_delta = game.InputEvent.mouse_x * move.RotateSpeed * delta;
+        let yaw_delta = game.InputEvent.MouseX * move.RotateSpeed * delta;
         if (yaw_delta !== 0) {
             move.Yaws.push(from_axis([0, 0, 0, 0], AXIS_Y, -yaw_delta));
         }
     }
 
-    if (control.Pitch) {
+    if (control.Pitch && game.InputEvent.MouseY) {
         let move = game.World.Move[entity];
-        let pitch_delta = game.InputEvent.mouse_y * move.RotateSpeed * delta;
+        let pitch_delta = game.InputEvent.MouseY * move.RotateSpeed * delta;
         if (pitch_delta !== 0) {
             let new_pitch = control.CurrentPitch + pitch_delta;
             if (-0.2 < new_pitch && new_pitch < Math.PI / 2) {

--- a/play/Makefile
+++ b/play/Makefile
@@ -31,6 +31,6 @@ game.terser.js: game.tr.js
 		--timings \
 		--ecma 9 \
 		--mangle toplevel \
-		--mangle-props regex=/^[A-Z]/ \
+		--mangle-props keep_quoted,regex=/^[A-Z]/ \
 		--compress $(shell paste -sd, terser_compress.txt) \
 	> $@


### PR DESCRIPTION
- Replace the `InputState` and `InputEvent` interfaces with `Record<string, number>`. Most of the members are dynamically assigned anyways, via `evt.code` etc.
- Rename `InputEvent` to `InputDelta` for better mangling. `InputEvent` is a reserved name of a [DOM interface](https://www.w3.org/TR/uievents/#interface-inputevent).
- Access keys whose name come from the DOM, like `KeyW`, using quoted indexing, `InputState["KeyW"]`, and add the `keep_quoted` option to Terser's `--mangle-props`.
- Capitalize custom names (not DOM-defined), e.g.`InputState.mouse_x` → `InputState.MouseX`, to take advantage of prop mangling.
- Fix handling of the `keydown` event, which repeatedly fires when a key is held down for an extended period of time.
- Rather than store two kinds of events for `keydown` and `keyup` (`InputDelta.KeyWDown` and `InputDelta.KeyWUp`), set `InputDelta.KeyW = 1` on `keydown`, and `InputDelta.KeyW = -1` on `keyup`.
- Remove input handling from examples that don't need it.