### PR TITLE
Refactor sys_light

### DIFF
--- a/Billboard/game.ts
+++ b/Billboard/game.ts
@@ -2,7 +2,6 @@ import {Material, Mesh} from "../common/material.js";
 import {GL_CULL_FACE, GL_CW, GL_DEPTH_TEST} from "../common/webgl.js";
 import {mesh_cube} from "../meshes/cube.js";
 import {Camera} from "./components/com_camera.js";
-import {Light} from "./components/com_light.js";
 import {loop_start, loop_stop} from "./core.js";
 import {mat_gouraud} from "./materials/mat_gouraud.js";
 import {sys_camera} from "./systems/sys_camera.js";
@@ -35,7 +34,8 @@ export class Game {
     MeshCube: Mesh;
 
     Cameras: Array<Camera> = [];
-    Lights: Array<Light> = [];
+    LightPositions: Array<number> = [];
+    LightDetails: Array<number> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/Billboard/scenes/sce_stage.ts
+++ b/Billboard/scenes/sce_stage.ts
@@ -9,7 +9,8 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Cameras = [];
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/Billboard/systems/sys_light.ts
+++ b/Billboard/systems/sys_light.ts
@@ -1,10 +1,13 @@
+import {get_translation} from "../../common/mat4.js";
+import {Vec3} from "../../common/math.js";
 import {Has} from "../components/com_index.js";
 import {Entity, Game} from "../game.js";
 
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
 
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
@@ -13,6 +16,12 @@ export function sys_light(game: Game, delta: number) {
     }
 }
 
+let world_pos: Vec3 = [0, 0, 0];
+
 function update(game: Game, entity: Entity) {
-    game.Lights.push(game.World.Light[entity]);
+    let light = game.World.Light[entity];
+    let transform = game.World.Transform[entity];
+    get_translation(world_pos, transform.World);
+    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2]);
+    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
 }

--- a/Billboard/systems/sys_render.ts
+++ b/Billboard/systems/sys_render.ts
@@ -1,4 +1,3 @@
-import {get_translation} from "../../common/mat4.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_UNSIGNED_SHORT} from "../../common/webgl.js";
 import {Has} from "../components/com_index.js";
 import {RenderKind} from "../components/com_render.js";
@@ -12,17 +11,6 @@ export function sys_render(game: Game, delta: number) {
     game.GL.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     if (game.ViewportResized) {
         game.GL.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-    }
-
-    let light_positions: Array<number> = [];
-    let light_details: Array<number> = [];
-
-    for (let i = 0; i < game.Lights.length; i++) {
-        let light = game.Lights[i];
-        let transform = game.World.Transform[light.EntityId];
-        let position = get_translation([0, 0, 0], transform.World);
-        light_positions.push(...position);
-        light_details.push(...light.Color, light.Intensity);
     }
 
     // Keep track of the current material to minimize switching.
@@ -44,15 +32,15 @@ export function sys_render(game: Game, delta: number) {
                     case RenderKind.Shaded:
                         game.GL.uniform1i(
                             current_material.Uniforms[ShadedUniform.LightCount],
-                            game.Lights.length
+                            game.LightPositions.length / 3
                         );
                         game.GL.uniform3fv(
                             current_material.Uniforms[ShadedUniform.LightPositions],
-                            light_positions
+                            game.LightPositions
                         );
                         game.GL.uniform4fv(
                             current_material.Uniforms[ShadedUniform.LightDetails],
-                            light_details
+                            game.LightDetails
                         );
                         break;
                 }

--- a/FlyCamera/game.ts
+++ b/FlyCamera/game.ts
@@ -2,7 +2,6 @@ import {Material, Mesh} from "../common/material.js";
 import {GL_CULL_FACE, GL_CW, GL_DEPTH_TEST} from "../common/webgl.js";
 import {mesh_cube} from "../meshes/cube.js";
 import {Camera} from "./components/com_camera.js";
-import {Light} from "./components/com_light.js";
 import {loop_start, loop_stop} from "./core.js";
 import {mat_gouraud} from "./materials/mat_gouraud.js";
 import {sys_camera} from "./systems/sys_camera.js";
@@ -32,7 +31,8 @@ export class Game {
     MeshCube: Mesh;
 
     Cameras: Array<Camera> = [];
-    Lights: Array<Light> = [];
+    LightPositions: Array<number> = [];
+    LightDetails: Array<number> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/FlyCamera/scenes/sce_stage.ts
+++ b/FlyCamera/scenes/sce_stage.ts
@@ -8,7 +8,8 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Cameras = [];
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/FlyCamera/systems/sys_light.ts
+++ b/FlyCamera/systems/sys_light.ts
@@ -1,10 +1,13 @@
+import {get_translation} from "../../common/mat4.js";
+import {Vec3} from "../../common/math.js";
 import {Has} from "../components/com_index.js";
 import {Entity, Game} from "../game.js";
 
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
 
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
@@ -13,6 +16,12 @@ export function sys_light(game: Game, delta: number) {
     }
 }
 
+let world_pos: Vec3 = [0, 0, 0];
+
 function update(game: Game, entity: Entity) {
-    game.Lights.push(game.World.Light[entity]);
+    let light = game.World.Light[entity];
+    let transform = game.World.Transform[entity];
+    get_translation(world_pos, transform.World);
+    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2]);
+    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
 }

--- a/FlyCamera/systems/sys_render.ts
+++ b/FlyCamera/systems/sys_render.ts
@@ -1,4 +1,3 @@
-import {get_translation} from "../../common/mat4.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_UNSIGNED_SHORT} from "../../common/webgl.js";
 import {Has} from "../components/com_index.js";
 import {RenderKind} from "../components/com_render.js";
@@ -12,17 +11,6 @@ export function sys_render(game: Game, delta: number) {
     game.GL.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     if (game.ViewportResized) {
         game.GL.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-    }
-
-    let light_positions: Array<number> = [];
-    let light_details: Array<number> = [];
-
-    for (let i = 0; i < game.Lights.length; i++) {
-        let light = game.Lights[i];
-        let transform = game.World.Transform[light.EntityId];
-        let position = get_translation([0, 0, 0], transform.World);
-        light_positions.push(...position);
-        light_details.push(...light.Color, light.Intensity);
     }
 
     // Keep track of the current material to minimize switching.
@@ -44,15 +32,15 @@ export function sys_render(game: Game, delta: number) {
                     case RenderKind.Shaded:
                         game.GL.uniform1i(
                             current_material.Uniforms[ShadedUniform.LightCount],
-                            game.Lights.length
+                            game.LightPositions.length / 3
                         );
                         game.GL.uniform3fv(
                             current_material.Uniforms[ShadedUniform.LightPositions],
-                            light_positions
+                            game.LightPositions
                         );
                         game.GL.uniform4fv(
                             current_material.Uniforms[ShadedUniform.LightDetails],
-                            light_details
+                            game.LightDetails
                         );
                         break;
                 }

--- a/Instancing/game.ts
+++ b/Instancing/game.ts
@@ -2,7 +2,6 @@ import {Material, Mesh} from "../common/material.js";
 import {GL_CULL_FACE, GL_CW, GL_DEPTH_TEST} from "../common/webgl.js";
 import {mesh_cube} from "../meshes/cube.js";
 import {Camera} from "./components/com_camera.js";
-import {Light} from "./components/com_light.js";
 import {loop_start, loop_stop} from "./core.js";
 import {mat_instanced} from "./materials/mat_instanced.js";
 import {sys_camera} from "./systems/sys_camera.js";
@@ -28,7 +27,8 @@ export class Game {
     MeshCube: Mesh;
 
     Cameras: Array<Camera> = [];
-    Lights: Array<Light> = [];
+    LightPositions: Array<number> = [];
+    LightDetails: Array<number> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/Instancing/scenes/sce_stage.ts
+++ b/Instancing/scenes/sce_stage.ts
@@ -8,7 +8,8 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Cameras = [];
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/Instancing/systems/sys_light.ts
+++ b/Instancing/systems/sys_light.ts
@@ -1,10 +1,13 @@
+import {get_translation} from "../../common/mat4.js";
+import {Vec3} from "../../common/math.js";
 import {Has} from "../components/com_index.js";
 import {Entity, Game} from "../game.js";
 
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
 
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
@@ -13,6 +16,12 @@ export function sys_light(game: Game, delta: number) {
     }
 }
 
+let world_pos: Vec3 = [0, 0, 0];
+
 function update(game: Game, entity: Entity) {
-    game.Lights.push(game.World.Light[entity]);
+    let light = game.World.Light[entity];
+    let transform = game.World.Transform[entity];
+    get_translation(world_pos, transform.World);
+    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2]);
+    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
 }

--- a/Instancing/systems/sys_render.ts
+++ b/Instancing/systems/sys_render.ts
@@ -1,4 +1,3 @@
-import {get_translation} from "../../common/mat4.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_UNSIGNED_SHORT} from "../../common/webgl.js";
 import {Has} from "../components/com_index.js";
 import {RenderKind} from "../components/com_render.js";
@@ -12,17 +11,6 @@ export function sys_render(game: Game, delta: number) {
     game.GL.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     if (game.ViewportResized) {
         game.GL.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-    }
-
-    let light_positions: Array<number> = [];
-    let light_details: Array<number> = [];
-
-    for (let i = 0; i < game.Lights.length; i++) {
-        let light = game.Lights[i];
-        let transform = game.World.Transform[light.EntityId];
-        let position = get_translation([0, 0, 0], transform.World);
-        light_positions.push(...position);
-        light_details.push(...light.Color, light.Intensity);
     }
 
     // Keep track of the current material to minimize switching.
@@ -44,15 +32,15 @@ export function sys_render(game: Game, delta: number) {
                     case RenderKind.Instanced:
                         game.GL.uniform1i(
                             current_material.Uniforms[InstancedUniform.LightCount],
-                            game.Lights.length
+                            game.LightPositions.length / 3
                         );
                         game.GL.uniform3fv(
                             current_material.Uniforms[InstancedUniform.LightPositions],
-                            light_positions
+                            game.LightPositions
                         );
                         game.GL.uniform4fv(
                             current_material.Uniforms[InstancedUniform.LightDetails],
-                            light_details
+                            game.LightDetails
                         );
                         break;
                 }

--- a/Monkey/game.ts
+++ b/Monkey/game.ts
@@ -3,7 +3,6 @@ import {GL_CULL_FACE, GL_CW, GL_DEPTH_TEST} from "../common/webgl.js";
 import {mesh_monkey_flat} from "../meshes/monkey_flat.js";
 import {mesh_monkey_smooth} from "../meshes/monkey_smooth.js";
 import {Camera} from "./components/com_camera.js";
-import {Light} from "./components/com_light.js";
 import {loop_start, loop_stop} from "./core.js";
 import {mat_flat} from "./materials/mat_flat.js";
 import {mat_phong} from "./materials/mat_phong.js";
@@ -32,7 +31,8 @@ export class Game {
     MeshMonkeySmooth: Mesh;
 
     Cameras: Array<Camera> = [];
-    Lights: Array<Light> = [];
+    LightPositions: Array<number> = [];
+    LightDetails: Array<number> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/Monkey/scenes/sce_stage.ts
+++ b/Monkey/scenes/sce_stage.ts
@@ -8,7 +8,8 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Cameras = [];
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/Monkey/systems/sys_light.ts
+++ b/Monkey/systems/sys_light.ts
@@ -1,10 +1,13 @@
+import {get_translation} from "../../common/mat4.js";
+import {Vec3} from "../../common/math.js";
 import {Has} from "../components/com_index.js";
 import {Entity, Game} from "../game.js";
 
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
 
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
@@ -13,6 +16,12 @@ export function sys_light(game: Game, delta: number) {
     }
 }
 
+let world_pos: Vec3 = [0, 0, 0];
+
 function update(game: Game, entity: Entity) {
-    game.Lights.push(game.World.Light[entity]);
+    let light = game.World.Light[entity];
+    let transform = game.World.Transform[entity];
+    get_translation(world_pos, transform.World);
+    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2]);
+    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
 }

--- a/Monkey/systems/sys_render.ts
+++ b/Monkey/systems/sys_render.ts
@@ -1,4 +1,3 @@
-import {get_translation} from "../../common/mat4.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_UNSIGNED_SHORT} from "../../common/webgl.js";
 import {Has} from "../components/com_index.js";
 import {RenderKind} from "../components/com_render.js";
@@ -12,17 +11,6 @@ export function sys_render(game: Game, delta: number) {
     game.GL.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     if (game.ViewportResized) {
         game.GL.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-    }
-
-    let light_positions: Array<number> = [];
-    let light_details: Array<number> = [];
-
-    for (let i = 0; i < game.Lights.length; i++) {
-        let light = game.Lights[i];
-        let transform = game.World.Transform[light.EntityId];
-        let position = get_translation([0, 0, 0], transform.World);
-        light_positions.push(...position);
-        light_details.push(...light.Color, light.Intensity);
     }
 
     // Keep track of the current material to minimize switching.
@@ -44,15 +32,15 @@ export function sys_render(game: Game, delta: number) {
                     case RenderKind.Shaded:
                         game.GL.uniform1i(
                             current_material.Uniforms[ShadedUniform.LightCount],
-                            game.Lights.length
+                            game.LightPositions.length / 3
                         );
                         game.GL.uniform3fv(
                             current_material.Uniforms[ShadedUniform.LightPositions],
-                            light_positions
+                            game.LightPositions
                         );
                         game.GL.uniform4fv(
                             current_material.Uniforms[ShadedUniform.LightDetails],
-                            light_details
+                            game.LightDetails
                         );
                         break;
                 }

--- a/NewProject3D/components/com_light.ts
+++ b/NewProject3D/components/com_light.ts
@@ -3,16 +3,14 @@ import {Entity, Game} from "../game.js";
 import {Has} from "./com_index.js";
 
 export interface Light {
-    EntityId: Entity;
     Color: Vec3;
     Intensity: number;
 }
 
 export function light(color: Vec3 = [1, 1, 1], range: number = 1) {
-    return (game: Game, EntityId: Entity) => {
-        game.World.Mask[EntityId] |= Has.Light;
-        game.World.Light[EntityId] = <Light>{
-            EntityId,
+    return (game: Game, entity: Entity) => {
+        game.World.Mask[entity] |= Has.Light;
+        game.World.Light[entity] = <Light>{
             Color: color,
             Intensity: range ** 2,
         };

--- a/NewProject3D/game.ts
+++ b/NewProject3D/game.ts
@@ -2,7 +2,6 @@ import {Material, Mesh} from "../common/material.js";
 import {GL_CULL_FACE, GL_CW, GL_DEPTH_TEST} from "../common/webgl.js";
 import {mesh_cube} from "../meshes/cube.js";
 import {Camera} from "./components/com_camera.js";
-import {Light} from "./components/com_light.js";
 import {loop_start, loop_stop} from "./core.js";
 import {mat_gouraud} from "./materials/mat_gouraud.js";
 import {sys_camera} from "./systems/sys_camera.js";
@@ -30,7 +29,8 @@ export class Game {
     MeshCube: Mesh;
 
     Cameras: Array<Camera> = [];
-    Lights: Array<Light> = [];
+    LightPositions: Array<number> = [];
+    LightDetails: Array<number> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/NewProject3D/scenes/sce_stage.ts
+++ b/NewProject3D/scenes/sce_stage.ts
@@ -8,7 +8,8 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Cameras = [];
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/NewProject3D/systems/sys_light.ts
+++ b/NewProject3D/systems/sys_light.ts
@@ -1,10 +1,13 @@
+import {get_translation} from "../../common/mat4.js";
+import {Vec3} from "../../common/math.js";
 import {Has} from "../components/com_index.js";
 import {Entity, Game} from "../game.js";
 
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
 
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
@@ -13,6 +16,12 @@ export function sys_light(game: Game, delta: number) {
     }
 }
 
+let world_pos: Vec3 = [0, 0, 0];
+
 function update(game: Game, entity: Entity) {
-    game.Lights.push(game.World.Light[entity]);
+    let light = game.World.Light[entity];
+    let transform = game.World.Transform[entity];
+    get_translation(world_pos, transform.World);
+    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2]);
+    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
 }

--- a/NewProject3D/systems/sys_render.ts
+++ b/NewProject3D/systems/sys_render.ts
@@ -1,4 +1,3 @@
-import {get_translation} from "../../common/mat4.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_UNSIGNED_SHORT} from "../../common/webgl.js";
 import {Has} from "../components/com_index.js";
 import {RenderKind} from "../components/com_render.js";
@@ -12,17 +11,6 @@ export function sys_render(game: Game, delta: number) {
     game.GL.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     if (game.ViewportResized) {
         game.GL.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-    }
-
-    let light_positions: Array<number> = [];
-    let light_details: Array<number> = [];
-
-    for (let i = 0; i < game.Lights.length; i++) {
-        let light = game.Lights[i];
-        let transform = game.World.Transform[light.EntityId];
-        let position = get_translation([0, 0, 0], transform.World);
-        light_positions.push(...position);
-        light_details.push(...light.Color, light.Intensity);
     }
 
     // Keep track of the current material to minimize switching.
@@ -44,15 +32,15 @@ export function sys_render(game: Game, delta: number) {
                     case RenderKind.Shaded:
                         game.GL.uniform1i(
                             current_material.Uniforms[ShadedUniform.LightCount],
-                            game.Lights.length
+                            game.LightPositions.length / 3
                         );
                         game.GL.uniform3fv(
                             current_material.Uniforms[ShadedUniform.LightPositions],
-                            light_positions
+                            game.LightPositions
                         );
                         game.GL.uniform4fv(
                             current_material.Uniforms[ShadedUniform.LightDetails],
-                            light_details
+                            game.LightDetails
                         );
                         break;
                 }

--- a/RigidBody/game.ts
+++ b/RigidBody/game.ts
@@ -2,7 +2,6 @@ import {Material, Mesh} from "../common/material.js";
 import {GL_CULL_FACE, GL_CW, GL_DEPTH_TEST} from "../common/webgl.js";
 import {mesh_cube} from "../meshes/cube.js";
 import {Camera} from "./components/com_camera.js";
-import {Light} from "./components/com_light.js";
 import {loop_start, loop_stop} from "./core.js";
 import {mat_gouraud} from "./materials/mat_gouraud.js";
 import {sys_camera} from "./systems/sys_camera.js";
@@ -32,7 +31,8 @@ export class Game {
     MeshCube: Mesh;
 
     Cameras: Array<Camera> = [];
-    Lights: Array<Light> = [];
+    LightPositions: Array<number> = [];
+    LightDetails: Array<number> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/RigidBody/scenes/sce_stage.ts
+++ b/RigidBody/scenes/sce_stage.ts
@@ -11,7 +11,8 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Cameras = [];
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/RigidBody/systems/sys_light.ts
+++ b/RigidBody/systems/sys_light.ts
@@ -1,10 +1,13 @@
+import {get_translation} from "../../common/mat4.js";
+import {Vec3} from "../../common/math.js";
 import {Has} from "../components/com_index.js";
 import {Entity, Game} from "../game.js";
 
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
 
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
@@ -13,6 +16,12 @@ export function sys_light(game: Game, delta: number) {
     }
 }
 
+let world_pos: Vec3 = [0, 0, 0];
+
 function update(game: Game, entity: Entity) {
-    game.Lights.push(game.World.Light[entity]);
+    let light = game.World.Light[entity];
+    let transform = game.World.Transform[entity];
+    get_translation(world_pos, transform.World);
+    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2]);
+    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
 }

--- a/RigidBody/systems/sys_render.ts
+++ b/RigidBody/systems/sys_render.ts
@@ -1,4 +1,3 @@
-import {get_translation} from "../../common/mat4.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_UNSIGNED_SHORT} from "../../common/webgl.js";
 import {Has} from "../components/com_index.js";
 import {RenderKind} from "../components/com_render.js";
@@ -12,17 +11,6 @@ export function sys_render(game: Game, delta: number) {
     game.GL.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     if (game.ViewportResized) {
         game.GL.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-    }
-
-    let light_positions: Array<number> = [];
-    let light_details: Array<number> = [];
-
-    for (let i = 0; i < game.Lights.length; i++) {
-        let light = game.Lights[i];
-        let transform = game.World.Transform[light.EntityId];
-        let position = get_translation([0, 0, 0], transform.World);
-        light_positions.push(...position);
-        light_details.push(...light.Color, light.Intensity);
     }
 
     // Keep track of the current material to minimize switching.
@@ -44,15 +32,15 @@ export function sys_render(game: Game, delta: number) {
                     case RenderKind.Shaded:
                         game.GL.uniform1i(
                             current_material.Uniforms[ShadedUniform.LightCount],
-                            game.Lights.length
+                            game.LightPositions.length / 3
                         );
                         game.GL.uniform3fv(
                             current_material.Uniforms[ShadedUniform.LightPositions],
-                            light_positions
+                            game.LightPositions
                         );
                         game.GL.uniform4fv(
                             current_material.Uniforms[ShadedUniform.LightDetails],
-                            light_details
+                            game.LightDetails
                         );
                         break;
                 }

--- a/Shading/game.ts
+++ b/Shading/game.ts
@@ -4,7 +4,6 @@ import {mesh_cube} from "../meshes/cube.js";
 import {mesh_icosphere_flat} from "../meshes/icosphere_flat.js";
 import {mesh_icosphere_smooth} from "../meshes/icosphere_smooth.js";
 import {Camera} from "./components/com_camera.js";
-import {Light} from "./components/com_light.js";
 import {loop_start, loop_stop} from "./core.js";
 import {mat_basic} from "./materials/mat_basic.js";
 import {mat_flat} from "./materials/mat_flat.js";
@@ -43,7 +42,8 @@ export class Game {
     MeshIcosphereSmooth: Mesh;
 
     Cameras: Array<Camera> = [];
-    Lights: Array<Light> = [];
+    LightPositions: Array<number> = [];
+    LightDetails: Array<number> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/Shading/scenes/sce_stage.ts
+++ b/Shading/scenes/sce_stage.ts
@@ -9,7 +9,8 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Cameras = [];
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/Shading/systems/sys_light.ts
+++ b/Shading/systems/sys_light.ts
@@ -1,10 +1,13 @@
+import {get_translation} from "../../common/mat4.js";
+import {Vec3} from "../../common/math.js";
 import {Has} from "../components/com_index.js";
 import {Entity, Game} from "../game.js";
 
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
 
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
@@ -13,6 +16,12 @@ export function sys_light(game: Game, delta: number) {
     }
 }
 
+let world_pos: Vec3 = [0, 0, 0];
+
 function update(game: Game, entity: Entity) {
-    game.Lights.push(game.World.Light[entity]);
+    let light = game.World.Light[entity];
+    let transform = game.World.Transform[entity];
+    get_translation(world_pos, transform.World);
+    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2]);
+    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
 }

--- a/Shading/systems/sys_render.ts
+++ b/Shading/systems/sys_render.ts
@@ -1,4 +1,3 @@
-import {get_translation} from "../../common/mat4.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_UNSIGNED_SHORT} from "../../common/webgl.js";
 import {Has} from "../components/com_index.js";
 import {RenderKind} from "../components/com_render.js";
@@ -13,17 +12,6 @@ export function sys_render(game: Game, delta: number) {
     game.GL.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     if (game.ViewportResized) {
         game.GL.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-    }
-
-    let light_positions: Array<number> = [];
-    let light_details: Array<number> = [];
-
-    for (let i = 0; i < game.Lights.length; i++) {
-        let light = game.Lights[i];
-        let transform = game.World.Transform[light.EntityId];
-        let position = get_translation([0, 0, 0], transform.World);
-        light_positions.push(...position);
-        light_details.push(...light.Color, light.Intensity);
     }
 
     // Keep track of the current material to minimize switching.
@@ -45,15 +33,15 @@ export function sys_render(game: Game, delta: number) {
                     case RenderKind.Shaded:
                         game.GL.uniform1i(
                             current_material.Uniforms[ShadedUniform.LightCount],
-                            game.Lights.length
+                            game.LightPositions.length / 3
                         );
                         game.GL.uniform3fv(
                             current_material.Uniforms[ShadedUniform.LightPositions],
-                            light_positions
+                            game.LightPositions
                         );
                         game.GL.uniform4fv(
                             current_material.Uniforms[ShadedUniform.LightDetails],
-                            light_details
+                            game.LightDetails
                         );
                         break;
                 }

--- a/ThirdPerson/game.ts
+++ b/ThirdPerson/game.ts
@@ -2,7 +2,6 @@ import {Material, Mesh} from "../common/material.js";
 import {GL_CULL_FACE, GL_CW, GL_DEPTH_TEST} from "../common/webgl.js";
 import {mesh_cube} from "../meshes/cube.js";
 import {Camera} from "./components/com_camera.js";
-import {Light} from "./components/com_light.js";
 import {loop_start, loop_stop} from "./core.js";
 import {mat_gouraud} from "./materials/mat_gouraud.js";
 import {sys_camera} from "./systems/sys_camera.js";
@@ -35,7 +34,8 @@ export class Game {
     MeshCube: Mesh;
 
     Cameras: Array<Camera> = [];
-    Lights: Array<Light> = [];
+    LightPositions: Array<number> = [];
+    LightDetails: Array<number> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/ThirdPerson/scenes/sce_stage.ts
+++ b/ThirdPerson/scenes/sce_stage.ts
@@ -8,7 +8,8 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Cameras = [];
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/ThirdPerson/systems/sys_light.ts
+++ b/ThirdPerson/systems/sys_light.ts
@@ -1,10 +1,13 @@
+import {get_translation} from "../../common/mat4.js";
+import {Vec3} from "../../common/math.js";
 import {Has} from "../components/com_index.js";
 import {Entity, Game} from "../game.js";
 
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.Lights = [];
+    game.LightPositions = [];
+    game.LightDetails = [];
 
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
@@ -13,6 +16,12 @@ export function sys_light(game: Game, delta: number) {
     }
 }
 
+let world_pos: Vec3 = [0, 0, 0];
+
 function update(game: Game, entity: Entity) {
-    game.Lights.push(game.World.Light[entity]);
+    let light = game.World.Light[entity];
+    let transform = game.World.Transform[entity];
+    get_translation(world_pos, transform.World);
+    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2]);
+    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
 }

--- a/ThirdPerson/systems/sys_render.ts
+++ b/ThirdPerson/systems/sys_render.ts
@@ -1,4 +1,3 @@
-import {get_translation} from "../../common/mat4.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT, GL_UNSIGNED_SHORT} from "../../common/webgl.js";
 import {Has} from "../components/com_index.js";
 import {RenderKind} from "../components/com_render.js";
@@ -12,17 +11,6 @@ export function sys_render(game: Game, delta: number) {
     game.GL.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     if (game.ViewportResized) {
         game.GL.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-    }
-
-    let light_positions: Array<number> = [];
-    let light_details: Array<number> = [];
-
-    for (let i = 0; i < game.Lights.length; i++) {
-        let light = game.Lights[i];
-        let transform = game.World.Transform[light.EntityId];
-        let position = get_translation([0, 0, 0], transform.World);
-        light_positions.push(...position);
-        light_details.push(...light.Color, light.Intensity);
     }
 
     // Keep track of the current material to minimize switching.
@@ -44,15 +32,15 @@ export function sys_render(game: Game, delta: number) {
                     case RenderKind.Shaded:
                         game.GL.uniform1i(
                             current_material.Uniforms[ShadedUniform.LightCount],
-                            game.Lights.length
+                            game.LightPositions.length / 3
                         );
                         game.GL.uniform3fv(
                             current_material.Uniforms[ShadedUniform.LightPositions],
-                            light_positions
+                            game.LightPositions
                         );
                         game.GL.uniform4fv(
                             current_material.Uniforms[ShadedUniform.LightDetails],
-                            light_details
+                            game.LightDetails
                         );
                         break;
                 }


### PR DESCRIPTION
- Store light positions and details directly on `Game`.
- Reuse a `Vec3` for calculating light's world position.
- Avoid spreading vectors (`game.LightPositions.push(...world_pos)`).