### PR TITLE
Use Float32Arrays to store light data

### DIFF
--- a/FlyCamera/components/com_light.ts
+++ b/FlyCamera/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/FlyCamera/components/com_render_diffuse.ts
+++ b/FlyCamera/components/com_render_diffuse.ts
@@ -59,7 +59,6 @@ export const enum DiffuseUniform {
     World,
     Self,
     Color,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/FlyCamera/game.ts
+++ b/FlyCamera/game.ts
@@ -35,8 +35,9 @@ export class Game {
     MeshCube = mesh_cube(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/FlyCamera/materials/mat_diffuse_gouraud.ts
+++ b/FlyCamera/materials/mat_diffuse_gouraud.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_gouraud(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/FlyCamera/scenes/sce_stage.ts
+++ b/FlyCamera/scenes/sce_stage.ts
@@ -9,8 +9,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/FlyCamera/systems/sys_light.ts
+++ b/FlyCamera/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/FlyCamera/systems/sys_render.ts
+++ b/FlyCamera/systems/sys_render.ts
@@ -49,7 +49,6 @@ export function sys_render(game: Game, delta: number) {
 function use_diffuse(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[DiffuseUniform.PV], false, game.Camera!.PV);
-    game.GL.uniform1i(material.Uniforms[DiffuseUniform.LightCount], game.LightPositions.length / 3);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightDetails], game.LightDetails);
 }

--- a/Instancing/components/com_light.ts
+++ b/Instancing/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/Instancing/components/com_render_instanced.ts
+++ b/Instancing/components/com_render_instanced.ts
@@ -73,7 +73,6 @@ export const enum InstancedUniform {
     World,
     Self,
     Palette,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/Instancing/game.ts
+++ b/Instancing/game.ts
@@ -27,8 +27,9 @@ export class Game {
     MeshCube = mesh_cube(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/Instancing/materials/mat_instanced.ts
+++ b/Instancing/materials/mat_instanced.ts
@@ -3,14 +3,18 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {InstancedAttribute} from "../components/com_render_instanced.js";
 
 let vertex = `#version 300 es\n
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec3 palette[16];
 
     uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${InstancedAttribute.Position}) in vec3 position;
     layout(location=${InstancedAttribute.Normal}) in vec3 normal;
@@ -26,12 +30,16 @@ let vertex = `#version 300 es\n
         vec3 color = palette[int(offset[3])];
         vec3 rgb = color * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -74,7 +82,6 @@ export function mat_instanced(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "palette")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Instancing/scenes/sce_stage.ts
+++ b/Instancing/scenes/sce_stage.ts
@@ -8,8 +8,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/Instancing/systems/sys_light.ts
+++ b/Instancing/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/Instancing/systems/sys_render.ts
+++ b/Instancing/systems/sys_render.ts
@@ -49,10 +49,6 @@ export function sys_render(game: Game, delta: number) {
 function use_instanced(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[InstancedUniform.PV], false, game.Camera!.PV);
-    game.GL.uniform1i(
-        material.Uniforms[InstancedUniform.LightCount],
-        game.LightPositions.length / 3
-    );
     game.GL.uniform4fv(material.Uniforms[InstancedUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[InstancedUniform.LightDetails], game.LightDetails);
 }

--- a/Monkey/components/com_light.ts
+++ b/Monkey/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/Monkey/components/com_render_diffuse.ts
+++ b/Monkey/components/com_render_diffuse.ts
@@ -59,7 +59,6 @@ export const enum DiffuseUniform {
     World,
     Self,
     Color,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/Monkey/components/com_render_specular.ts
+++ b/Monkey/components/com_render_specular.ts
@@ -72,7 +72,6 @@ export const enum SpecularUniform {
     ColorDiffuse,
     ColorSpecular,
     Shininess,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/Monkey/game.ts
+++ b/Monkey/game.ts
@@ -31,8 +31,9 @@ export class Game {
     MeshMonkeySmooth = mesh_monkey_smooth(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/Monkey/materials/mat_diffuse_flat.ts
+++ b/Monkey/materials/mat_diffuse_flat.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_flat(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Monkey/materials/mat_specular_phong.ts
+++ b/Monkey/materials/mat_specular_phong.ts
@@ -22,13 +22,15 @@ let vertex = `#version 300 es
 let fragment = `#version 300 es
     precision mediump float;
 
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform vec3 eye;
     uniform vec4 color_diffuse;
     uniform vec4 color_specular;
     uniform float shininess;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     in vec4 vert_pos;
     in vec3 vert_normal;
@@ -43,12 +45,16 @@ let fragment = `#version 300 es
         // Ambient light.
         vec3 rgb = color_diffuse.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -96,7 +102,6 @@ export function mat_specular_phong(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "color_diffuse")!,
             gl.getUniformLocation(Program, "color_specular")!,
             gl.getUniformLocation(Program, "shininess")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Monkey/scenes/sce_stage.ts
+++ b/Monkey/scenes/sce_stage.ts
@@ -9,8 +9,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/Monkey/systems/sys_light.ts
+++ b/Monkey/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/Monkey/systems/sys_render.ts
+++ b/Monkey/systems/sys_render.ts
@@ -56,7 +56,6 @@ export function sys_render(game: Game, delta: number) {
 function use_diffuse(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[DiffuseUniform.PV], false, game.Camera!.PV);
-    game.GL.uniform1i(material.Uniforms[DiffuseUniform.LightCount], game.LightPositions.length / 3);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightDetails], game.LightDetails);
 }
@@ -78,10 +77,6 @@ function use_specular(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[SpecularUniform.PV], false, game.Camera!.PV);
     game.GL.uniform3fv(material.Uniforms[SpecularUniform.Eye], game.Camera!.Position);
-    game.GL.uniform1i(
-        material.Uniforms[SpecularUniform.LightCount],
-        game.LightPositions.length / 3
-    );
     game.GL.uniform4fv(material.Uniforms[SpecularUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[SpecularUniform.LightDetails], game.LightDetails);
 }

--- a/NewProject3D/components/com_light.ts
+++ b/NewProject3D/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/NewProject3D/components/com_render_diffuse.ts
+++ b/NewProject3D/components/com_render_diffuse.ts
@@ -59,7 +59,6 @@ export const enum DiffuseUniform {
     World,
     Self,
     Color,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/NewProject3D/game.ts
+++ b/NewProject3D/game.ts
@@ -30,8 +30,9 @@ export class Game {
     MeshCube = mesh_cube(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/NewProject3D/materials/mat_diffuse_gouraud.ts
+++ b/NewProject3D/materials/mat_diffuse_gouraud.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_gouraud(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/NewProject3D/scenes/sce_stage.ts
+++ b/NewProject3D/scenes/sce_stage.ts
@@ -8,8 +8,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/NewProject3D/systems/sys_light.ts
+++ b/NewProject3D/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/NewProject3D/systems/sys_render.ts
+++ b/NewProject3D/systems/sys_render.ts
@@ -49,7 +49,6 @@ export function sys_render(game: Game, delta: number) {
 function use_diffuse(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[DiffuseUniform.PV], false, game.Camera!.PV);
-    game.GL.uniform1i(material.Uniforms[DiffuseUniform.LightCount], game.LightPositions.length / 3);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightDetails], game.LightDetails);
 }

--- a/RigidBody/components/com_light.ts
+++ b/RigidBody/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/RigidBody/components/com_render_diffuse.ts
+++ b/RigidBody/components/com_render_diffuse.ts
@@ -59,7 +59,6 @@ export const enum DiffuseUniform {
     World,
     Self,
     Color,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/RigidBody/game.ts
+++ b/RigidBody/game.ts
@@ -31,8 +31,9 @@ export class Game {
     MeshCube = mesh_cube(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/RigidBody/materials/mat_diffuse_gouraud.ts
+++ b/RigidBody/materials/mat_diffuse_gouraud.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_gouraud(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/RigidBody/scenes/sce_stage.ts
+++ b/RigidBody/scenes/sce_stage.ts
@@ -11,8 +11,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/RigidBody/systems/sys_light.ts
+++ b/RigidBody/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/RigidBody/systems/sys_render.ts
+++ b/RigidBody/systems/sys_render.ts
@@ -49,7 +49,6 @@ export function sys_render(game: Game, delta: number) {
 function use_diffuse(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[DiffuseUniform.PV], false, game.Camera!.PV);
-    game.GL.uniform1i(material.Uniforms[DiffuseUniform.LightCount], game.LightPositions.length / 3);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightDetails], game.LightDetails);
 }

--- a/Shading/components/com_light.ts
+++ b/Shading/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/Shading/components/com_render_diffuse.ts
+++ b/Shading/components/com_render_diffuse.ts
@@ -59,7 +59,6 @@ export const enum DiffuseUniform {
     World,
     Self,
     Color,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/Shading/components/com_render_specular.ts
+++ b/Shading/components/com_render_specular.ts
@@ -72,7 +72,6 @@ export const enum SpecularUniform {
     ColorDiffuse,
     ColorSpecular,
     Shininess,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/Shading/game.ts
+++ b/Shading/game.ts
@@ -49,8 +49,9 @@ export class Game {
     MeshIcosphereSmooth = mesh_icosphere_smooth(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/Shading/materials/mat_diffuse_flat.ts
+++ b/Shading/materials/mat_diffuse_flat.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_flat(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Shading/materials/mat_diffuse_gouraud.ts
+++ b/Shading/materials/mat_diffuse_gouraud.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_gouraud(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Shading/materials/mat_diffuse_phong.ts
+++ b/Shading/materials/mat_diffuse_phong.ts
@@ -22,10 +22,12 @@ let vertex = `#version 300 es
 let fragment = `#version 300 es
     precision mediump float;
 
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     in vec4 vert_pos;
     in vec3 vert_normal;
@@ -37,12 +39,16 @@ let fragment = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -74,7 +80,6 @@ export function mat_diffuse_phong(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Shading/materials/mat_specular_flat.ts
+++ b/Shading/materials/mat_specular_flat.ts
@@ -3,6 +3,10 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {SpecularAttribute} from "../components/com_render_specular.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
@@ -10,9 +14,8 @@ let vertex = `#version 300 es
     uniform vec4 color_diffuse;
     uniform vec4 color_specular;
     uniform float shininess;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${SpecularAttribute.Position}) in vec3 position;
     layout(location=${SpecularAttribute.Normal}) in vec3 normal;
@@ -29,12 +32,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color_diffuse.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -88,7 +95,6 @@ export function mat_specular_flat(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "color_diffuse")!,
             gl.getUniformLocation(Program, "color_specular")!,
             gl.getUniformLocation(Program, "shininess")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Shading/materials/mat_specular_gouraud.ts
+++ b/Shading/materials/mat_specular_gouraud.ts
@@ -3,6 +3,10 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {SpecularAttribute} from "../components/com_render_specular.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
@@ -10,9 +14,8 @@ let vertex = `#version 300 es
     uniform vec4 color_diffuse;
     uniform vec4 color_specular;
     uniform float shininess;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${SpecularAttribute.Position}) in vec3 position;
     layout(location=${SpecularAttribute.Normal}) in vec3 normal;
@@ -29,12 +32,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color_diffuse.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -88,7 +95,6 @@ export function mat_specular_gouraud(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "color_diffuse")!,
             gl.getUniformLocation(Program, "color_specular")!,
             gl.getUniformLocation(Program, "shininess")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Shading/materials/mat_specular_phong.ts
+++ b/Shading/materials/mat_specular_phong.ts
@@ -22,13 +22,15 @@ let vertex = `#version 300 es
 let fragment = `#version 300 es
     precision mediump float;
 
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform vec3 eye;
     uniform vec4 color_diffuse;
     uniform vec4 color_specular;
     uniform float shininess;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     in vec4 vert_pos;
     in vec3 vert_normal;
@@ -43,12 +45,16 @@ let fragment = `#version 300 es
         // Ambient light.
         vec3 rgb = color_diffuse.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -96,7 +102,6 @@ export function mat_specular_phong(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "color_diffuse")!,
             gl.getUniformLocation(Program, "color_specular")!,
             gl.getUniformLocation(Program, "shininess")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/Shading/scenes/sce_stage.ts
+++ b/Shading/scenes/sce_stage.ts
@@ -11,8 +11,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/Shading/systems/sys_light.ts
+++ b/Shading/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/Shading/systems/sys_render.ts
+++ b/Shading/systems/sys_render.ts
@@ -76,7 +76,6 @@ function draw_basic(game: Game, transform: Transform, render: RenderBasic) {
 function use_diffuse(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[DiffuseUniform.PV], false, game.Camera!.PV);
-    game.GL.uniform1i(material.Uniforms[DiffuseUniform.LightCount], game.LightPositions.length / 3);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightDetails], game.LightDetails);
 }
@@ -98,10 +97,6 @@ function use_specular(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[SpecularUniform.PV], false, game.Camera!.PV);
     game.GL.uniform3fv(material.Uniforms[SpecularUniform.Eye], game.Camera!.Position);
-    game.GL.uniform1i(
-        material.Uniforms[SpecularUniform.LightCount],
-        game.LightPositions.length / 3
-    );
     game.GL.uniform4fv(material.Uniforms[SpecularUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[SpecularUniform.LightDetails], game.LightDetails);
 }

--- a/ThirdPerson/components/com_light.ts
+++ b/ThirdPerson/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/ThirdPerson/components/com_render_diffuse.ts
+++ b/ThirdPerson/components/com_render_diffuse.ts
@@ -59,7 +59,6 @@ export const enum DiffuseUniform {
     World,
     Self,
     Color,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/ThirdPerson/game.ts
+++ b/ThirdPerson/game.ts
@@ -35,8 +35,9 @@ export class Game {
     MeshCube = mesh_cube(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/ThirdPerson/materials/mat_diffuse_gouraud.ts
+++ b/ThirdPerson/materials/mat_diffuse_gouraud.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_gouraud(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/ThirdPerson/scenes/sce_stage.ts
+++ b/ThirdPerson/scenes/sce_stage.ts
@@ -9,8 +9,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/ThirdPerson/systems/sys_light.ts
+++ b/ThirdPerson/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/ThirdPerson/systems/sys_render.ts
+++ b/ThirdPerson/systems/sys_render.ts
@@ -49,7 +49,6 @@ export function sys_render(game: Game, delta: number) {
 function use_diffuse(game: Game, material: Material) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[DiffuseUniform.PV], false, game.Camera!.PV);
-    game.GL.uniform1i(material.Uniforms[DiffuseUniform.LightCount], game.LightPositions.length / 3);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightDetails], game.LightDetails);
 }

--- a/WebVR/components/com_light.ts
+++ b/WebVR/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/WebVR/components/com_render_diffuse.ts
+++ b/WebVR/components/com_render_diffuse.ts
@@ -59,7 +59,6 @@ export const enum DiffuseUniform {
     World,
     Self,
     Color,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/WebVR/game.ts
+++ b/WebVR/game.ts
@@ -31,8 +31,9 @@ export class Game {
     MeshCube = mesh_cube(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/WebVR/materials/mat_diffuse_gouraud.ts
+++ b/WebVR/materials/mat_diffuse_gouraud.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_gouraud(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/WebVR/scenes/sce_stage.ts
+++ b/WebVR/scenes/sce_stage.ts
@@ -9,8 +9,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/WebVR/systems/sys_light.ts
+++ b/WebVR/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/WebVR/systems/sys_render.ts
+++ b/WebVR/systems/sys_render.ts
@@ -76,7 +76,6 @@ function render(game: Game, pv: Mat4) {
 function use_diffuse(game: Game, material: Material, pv: Mat4) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[DiffuseUniform.PV], false, pv);
-    game.GL.uniform1i(material.Uniforms[DiffuseUniform.LightCount], game.LightPositions.length / 3);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightDetails], game.LightDetails);
 }

--- a/WebXR/components/com_light.ts
+++ b/WebXR/components/com_light.ts
@@ -5,6 +5,7 @@ import {Has} from "./com_index.js";
 export type Light = LightDirectional | LightPoint;
 
 export const enum LightKind {
+    Inactive,
     Directional,
     Point,
 }

--- a/WebXR/components/com_render_diffuse.ts
+++ b/WebXR/components/com_render_diffuse.ts
@@ -64,7 +64,6 @@ export const enum DiffuseUniform {
     World,
     Self,
     Color,
-    LightCount,
     LightPositions,
     LightDetails,
 }

--- a/WebXR/game.ts
+++ b/WebXR/game.ts
@@ -37,8 +37,9 @@ export class Game {
     MeshHand = mesh_hand(this.GL);
 
     Camera?: Camera;
-    LightPositions: Array<number> = [];
-    LightDetails: Array<number> = [];
+    // The rendering pipeline supports 8 lights.
+    LightPositions = new Float32Array(4 * 8);
+    LightDetails = new Float32Array(4 * 8);
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/WebXR/materials/mat_diffuse_gouraud.ts
+++ b/WebXR/materials/mat_diffuse_gouraud.ts
@@ -3,13 +3,16 @@ import {GL_TRIANGLES} from "../../common/webgl.js";
 import {DiffuseAttribute} from "../components/com_render_diffuse.js";
 
 let vertex = `#version 300 es
+
+    // See Game.LightPositions and Game.LightDetails.
+    const int MAX_LIGHTS = 8;
+
     uniform mat4 pv;
     uniform mat4 world;
     uniform mat4 self;
     uniform vec4 color;
-    uniform int light_count;
-    uniform vec4 light_positions[10];
-    uniform vec4 light_details[10];
+    uniform vec4 light_positions[MAX_LIGHTS];
+    uniform vec4 light_details[MAX_LIGHTS];
 
     layout(location=${DiffuseAttribute.Position}) in vec3 position;
     layout(location=${DiffuseAttribute.Normal}) in vec3 normal;
@@ -23,12 +26,16 @@ let vertex = `#version 300 es
         // Ambient light.
         vec3 rgb = color.rgb * 0.1;
 
-        for (int i = 0; i < light_count; i++) {
+        for (int i = 0; i < MAX_LIGHTS; i++) {
+            if (light_positions[i].w == 0.0) {
+                break;
+            }
+
             vec3 light_color = light_details[i].rgb;
             float light_intensity = light_details[i].a;
 
             vec3 light_normal;
-            if (light_positions[i].w == 0.0) {
+            if (light_positions[i].w == 1.0) {
                 // Directional light.
                 light_normal = light_positions[i].xyz;
             } else {
@@ -71,7 +78,6 @@ export function mat_diffuse_gouraud(gl: WebGL2RenderingContext) {
             gl.getUniformLocation(Program, "world")!,
             gl.getUniformLocation(Program, "self")!,
             gl.getUniformLocation(Program, "color")!,
-            gl.getUniformLocation(Program, "light_count")!,
             gl.getUniformLocation(Program, "light_positions")!,
             gl.getUniformLocation(Program, "light_details")!,
         ],

--- a/WebXR/scenes/sce_stage.ts
+++ b/WebXR/scenes/sce_stage.ts
@@ -9,8 +9,6 @@ import {World} from "../world.js";
 export function scene_stage(game: Game) {
     game.World = new World();
     game.Camera = undefined;
-    game.LightPositions = [];
-    game.LightDetails = [];
     game.ViewportResized = true;
     game.GL.clearColor(1, 0.3, 0.3, 1);
 

--- a/WebXR/systems/sys_light.ts
+++ b/WebXR/systems/sys_light.ts
@@ -8,19 +8,20 @@ import {Entity, Game} from "../game.js";
 const QUERY = Has.Transform | Has.Light;
 
 export function sys_light(game: Game, delta: number) {
-    game.LightPositions = [];
-    game.LightDetails = [];
+    game.LightPositions.fill(0);
+    game.LightDetails.fill(0);
 
+    let counter = 0;
     for (let i = 0; i < game.World.Mask.length; i++) {
         if ((game.World.Mask[i] & QUERY) === QUERY) {
-            update(game, i);
+            update(game, i, counter++);
         }
     }
 }
 
 let world_pos: Vec3 = [0, 0, 0];
 
-function update(game: Game, entity: Entity) {
+function update(game: Game, entity: Entity, idx: number) {
     let light = game.World.Light[entity];
     let transform = game.World.Transform[entity];
 
@@ -31,6 +32,12 @@ function update(game: Game, entity: Entity) {
         normalize(world_pos, world_pos);
     }
 
-    game.LightPositions.push(world_pos[0], world_pos[1], world_pos[2], light.Kind);
-    game.LightDetails.push(light.Color[0], light.Color[1], light.Color[2], light.Intensity);
+    game.LightPositions[4 * idx + 0] = world_pos[0];
+    game.LightPositions[4 * idx + 1] = world_pos[1];
+    game.LightPositions[4 * idx + 2] = world_pos[2];
+    game.LightPositions[4 * idx + 3] = light.Kind;
+    game.LightDetails[4 * idx + 0] = light.Color[0];
+    game.LightDetails[4 * idx + 1] = light.Color[1];
+    game.LightDetails[4 * idx + 2] = light.Color[2];
+    game.LightDetails[4 * idx + 3] = light.Intensity;
 }

--- a/WebXR/systems/sys_render.ts
+++ b/WebXR/systems/sys_render.ts
@@ -82,7 +82,6 @@ function render(game: Game, pv: Mat4) {
 function use_diffuse(game: Game, material: Material, pv: Mat4) {
     game.GL.useProgram(material.Program);
     game.GL.uniformMatrix4fv(material.Uniforms[DiffuseUniform.PV], false, pv);
-    game.GL.uniform1i(material.Uniforms[DiffuseUniform.LightCount], game.LightPositions.length / 3);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightPositions], game.LightPositions);
     game.GL.uniform4fv(material.Uniforms[DiffuseUniform.LightDetails], game.LightDetails);
 }


### PR DESCRIPTION
Light data is passed to shaders as uniforms of known length, so there's little need to store it in dynamically sized arrays on the CPU side. We can use pre-allocated `Float32Arrays` of the same known length instead.

In each frame, these arrays are filled with zeros, and then position, color and other data is written to them for each light present in the scene.

This has the benefit of making it possible to use `Light.Kind` to break out of the lighting loop in shaders, rather than pass the `light_count` uniform explicitly. As soon as the light's kind is `0`, we know we've already processed all lights currently active in the scene.

(This is how lights are often handled in WebGL1 shaders, where it's illegal to use uniform values in the loop's stop condition because the spec allows specifications to statically unroll loops.)