### PR TITLE
Add a simple Todo app

### DIFF
--- a/TodoApp/actions.ts
+++ b/TodoApp/actions.ts
@@ -1,0 +1,17 @@
+import {Game} from "./game.js";
+
+export const enum Action {
+    AddTodo,
+}
+
+export function dispatch(game: Game, action: Action, payload: unknown) {
+    switch (action) {
+        case Action.AddTodo: {
+            let todo = payload as string;
+            if (todo) {
+                game.Todos.push(todo);
+            }
+            break;
+        }
+    }
+}

--- a/TodoApp/actions.ts
+++ b/TodoApp/actions.ts
@@ -2,6 +2,7 @@ import {Game} from "./game.js";
 
 export const enum Action {
     AddTodo,
+    CompleteTodo,
 }
 
 export function dispatch(game: Game, action: Action, payload: unknown) {
@@ -10,6 +11,14 @@ export function dispatch(game: Game, action: Action, payload: unknown) {
             let todo = payload as string;
             if (todo) {
                 game.Todos.push(todo);
+            }
+            break;
+        }
+        case Action.CompleteTodo: {
+            let idx = payload as number;
+            if (idx < game.Todos.length) {
+                let removed = game.Todos.splice(idx, 1);
+                game.Completed.push(...removed);
             }
             break;
         }

--- a/TodoApp/core.ts
+++ b/TodoApp/core.ts
@@ -1,0 +1,21 @@
+import {Game} from "./game.js";
+
+let raf = 0;
+
+export function loop_start(game: Game) {
+    let last = performance.now();
+
+    let tick = (now: number) => {
+        let delta = (now - last) / 1000;
+        game.FrameUpdate(delta);
+        last = now;
+        raf = requestAnimationFrame(tick);
+    };
+
+    loop_stop();
+    tick(last);
+}
+
+export function loop_stop() {
+    cancelAnimationFrame(raf);
+}

--- a/TodoApp/game.ts
+++ b/TodoApp/game.ts
@@ -1,0 +1,23 @@
+import {loop_start, loop_stop} from "./core.js";
+import {sys_framerate} from "./systems/sys_framerate.js";
+import {sys_ui} from "./systems/sys_ui.js";
+
+type Todo = string;
+
+export class Game {
+    UI = document.querySelector("main")!;
+
+    Todos: Array<Todo> = [];
+
+    constructor() {
+        document.addEventListener("visibilitychange", () =>
+            document.hidden ? loop_stop() : loop_start(this)
+        );
+    }
+
+    FrameUpdate(delta: number) {
+        let now = performance.now();
+        sys_ui(this, delta);
+        sys_framerate(this, delta, performance.now() - now);
+    }
+}

--- a/TodoApp/game.ts
+++ b/TodoApp/game.ts
@@ -2,12 +2,11 @@ import {loop_start, loop_stop} from "./core.js";
 import {sys_framerate} from "./systems/sys_framerate.js";
 import {sys_ui} from "./systems/sys_ui.js";
 
-type Todo = string;
-
 export class Game {
     UI = document.querySelector("main")!;
 
-    Todos: Array<Todo> = [];
+    Todos: Array<string> = [];
+    Completed: Array<string> = [];
 
     constructor() {
         document.addEventListener("visibilitychange", () =>

--- a/TodoApp/index.html
+++ b/TodoApp/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<meta charset="utf8" />
+<meta name="viewport" content="width=device-width, user-scalable=0" />
+<title>TodoApp</title>
+<style>
+    html,
+    body {
+        overflow: hidden;
+        margin: 0;
+    }
+    canvas,
+    main {
+        position: absolute;
+        width: 100vw;
+        height: 100vh;
+        user-select: none;
+    }
+    #debug {
+        display: flex;
+        flex-flow: column nowrap;
+        align-items: flex-end;
+        position: absolute;
+        top: 0;
+        right: 0;
+        color: #fff;
+        font-family: monospace;
+    }
+    #debug button {
+        cursor: pointer;
+        padding: 0;
+        background: none;
+        border: none;
+        font: inherit;
+        color: inherit;
+    }
+    #debug div {
+        width: max-content;
+        background: #000;
+        color: #fff;
+    }
+</style>
+<body>
+    <canvas></canvas>
+    <main></main>
+
+    <div id="debug">
+        <div>update: <span id="update"></span></div>
+        <div>delta: <span id="delta"></span></div>
+        <div>fps: <span id="fps"></span></div>
+        <div><button onclick="toggle(this)">pause</button></div>
+    </div>
+    <script type="module">
+        import {loop_start, loop_stop} from "./core.js";
+        import "./index.js";
+
+        let running = true;
+        window.toggle = function toggle(button) {
+            if (running) {
+                running = false;
+                loop_stop();
+                button.textContent = "resume";
+            } else {
+                running = true;
+                loop_start(game);
+                button.textContent = "pause";
+            }
+        };
+    </script>
+</body>

--- a/TodoApp/index.ts
+++ b/TodoApp/index.ts
@@ -1,0 +1,12 @@
+import {dispatch} from "./actions.js";
+import {loop_start} from "./core.js";
+import {Game} from "./game.js";
+
+let game = new Game();
+loop_start(game);
+
+// @ts-ignore
+window.$ = dispatch.bind(null, game);
+
+// @ts-ignore
+window.game = game;

--- a/TodoApp/systems/sys_framerate.ts
+++ b/TodoApp/systems/sys_framerate.ts
@@ -1,0 +1,17 @@
+import {Game} from "../game.js";
+
+let update_span = document.getElementById("update");
+let delta_span = document.getElementById("delta");
+let fps_span = document.getElementById("fps");
+
+export function sys_framerate(game: Game, delta: number, update: number) {
+    if (update_span) {
+        update_span.textContent = update.toFixed(1);
+    }
+    if (delta_span) {
+        delta_span.textContent = (delta * 1000).toFixed(1);
+    }
+    if (fps_span) {
+        fps_span.textContent = (1 / delta).toFixed();
+    }
+}

--- a/TodoApp/systems/sys_ui.ts
+++ b/TodoApp/systems/sys_ui.ts
@@ -1,0 +1,11 @@
+import {Game} from "../game.js";
+import {App} from "../ui/App.js";
+
+let prev: string;
+
+export function sys_ui(game: Game, delta: number) {
+    let next = App(game);
+    if (next !== prev) {
+        game.UI.innerHTML = prev = next;
+    }
+}

--- a/TodoApp/ui/AddForm.ts
+++ b/TodoApp/ui/AddForm.ts
@@ -1,0 +1,16 @@
+import {Action} from "../actions.js";
+import {html} from "./html.js";
+
+export function AddForm() {
+    return html`
+        <input
+            type="text"
+            onkeypress="if (event.key === 'Enter') {
+                $(${Action.AddTodo}, this.value);
+            }"
+        />
+        <button onclick="$(${Action.AddTodo}, this.previousElementSibling.value)">
+            Add
+        </button>
+    `;
+}

--- a/TodoApp/ui/App.ts
+++ b/TodoApp/ui/App.ts
@@ -1,0 +1,22 @@
+import {Game} from "../game.js";
+import {AddForm} from "./AddForm.js";
+import {html} from "./html.js";
+import {TodoItem} from "./TodoItem.js";
+
+export function App(game: Game) {
+    return html`
+        <div style="padding: 20px; font: 14px Arial, sans-serif;">
+            <h1>Todo App</h1>
+            <div style="display: flex;">
+                <div style="flex: 1;">
+                    <ul>
+                        ${game.Todos.map(TodoItem)}
+                    </ul>
+                    <div>
+                        ${AddForm()}
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+}

--- a/TodoApp/ui/App.ts
+++ b/TodoApp/ui/App.ts
@@ -1,5 +1,6 @@
 import {Game} from "../game.js";
 import {AddForm} from "./AddForm.js";
+import {CompletedItem} from "./CompletedItem.js";
 import {html} from "./html.js";
 import {TodoItem} from "./TodoItem.js";
 
@@ -7,14 +8,19 @@ export function App(game: Game) {
     return html`
         <div style="padding: 20px; font: 14px Arial, sans-serif;">
             <h1>Todo App</h1>
+            <div>
+                ${AddForm()}
+            </div>
             <div style="display: flex;">
                 <div style="flex: 1;">
                     <ul>
                         ${game.Todos.map(TodoItem)}
                     </ul>
-                    <div>
-                        ${AddForm()}
-                    </div>
+                </div>
+                <div style="flex: 1;">
+                    <ul>
+                        ${game.Completed.map(CompletedItem)}
+                    </ul>
                 </div>
             </div>
         </div>

--- a/TodoApp/ui/CompletedItem.ts
+++ b/TodoApp/ui/CompletedItem.ts
@@ -1,0 +1,16 @@
+import {html} from "./html.js";
+
+export function CompletedItem(content: string) {
+    return html`
+        <li>
+            <span
+                style="
+                    color: #999;
+                    text-decoration: line-through;
+                "
+            >
+                ${content}
+            </span>
+        </li>
+    `;
+}

--- a/TodoApp/ui/TodoItem.ts
+++ b/TodoApp/ui/TodoItem.ts
@@ -1,0 +1,9 @@
+import {html} from "./html.js";
+
+export function TodoItem(content: string) {
+    return html`
+        <li>
+            ${content}
+        </li>
+    `;
+}

--- a/TodoApp/ui/TodoItem.ts
+++ b/TodoApp/ui/TodoItem.ts
@@ -1,9 +1,20 @@
+import {Action} from "../actions.js";
 import {html} from "./html.js";
 
-export function TodoItem(content: string) {
+export function TodoItem(content: string, idx: number) {
     return html`
         <li>
-            ${content}
+            <span>${content}</span>
+            <small
+                onclick="$(${Action.CompleteTodo}, ${idx})"
+                style="
+                    color: #00f;
+                    text-decoration: underline;
+                    cursor: pointer;
+                "
+            >
+                complete
+            </small>
         </li>
     `;
 }

--- a/TodoApp/ui/html.ts
+++ b/TodoApp/ui/html.ts
@@ -1,0 +1,16 @@
+type Interpolation = string | number | boolean | undefined | null | Array<Interpolation>;
+
+function shift(values: Array<Interpolation>) {
+    let value = values.shift();
+    if (typeof value === "boolean" || value == undefined) {
+        return "";
+    } else if (Array.isArray(value)) {
+        return value.join("");
+    } else {
+        return value;
+    }
+}
+
+export function html(strings: TemplateStringsArray, ...values: Array<Interpolation>) {
+    return strings.reduce((out, cur) => out + shift(values) + cur);
+}


### PR DESCRIPTION
The Todo app is an example of a UI built with `sys_ui`. The example is barebones; there's no actual game nor scene running under the UI. The `Game` instance still runs at 60fps via `rAF`, which is extremel wasteful in this example, but in a real-world game would be done anyways.

The Todo app showcases a few limitations of `sys_ui`:

- It's impossible to re-focus the text input after adding a new todo item. Once the UI re-renders, all elements are new and we don't have any handles to the old ones. (In React terms, elements only mount and unmount, rather than re-render). It's also impossible to run logic after an element "mounts". (In React terms, there's no `componentDidMount`).
- It's impossible to disable and enable the `Add` button dynamically based on the current value of the text input. The input keeps its own state, i.e. the characters the user has entered so far. Making any changes to the state would re-render the whole UI, destroying the input together with its state.
- There's no sanitization of user's input!

In summary, `sys_ui` is an extremely simple and lightweight UI system designed to render readonly data. If you use it to collect user input, you're doing it at your own risk.