### PR TITLE
Dynamic mesh imports

### DIFF
--- a/Monkey/game.ts
+++ b/Monkey/game.ts
@@ -1,8 +1,7 @@
+import {Mesh} from "../common/material.js";
 import {GL_CULL_FACE, GL_DEPTH_TEST} from "../common/webgl.js";
 import {mat1_diffuse_gouraud} from "../materials/mat1_diffuse_gouraud.js";
 import {mat1_specular_phong} from "../materials/mat1_specular_phong.js";
-import {mesh_monkey_flat} from "../meshes/monkey_flat.js";
-import {mesh_monkey_smooth} from "../meshes/monkey_smooth.js";
 import {Camera} from "./components/com_camera.js";
 import {loop_start, loop_stop} from "./core.js";
 import {sys_camera} from "./systems/sys_camera.js";
@@ -28,8 +27,8 @@ export class Game {
 
     MaterialDiffuseGouraud = mat1_diffuse_gouraud(this.Gl);
     MaterialSpecularPhong = mat1_specular_phong(this.Gl);
-    MeshMonkeyFlat = mesh_monkey_flat(this.Gl);
-    MeshMonkeySmooth = mesh_monkey_smooth(this.Gl);
+
+    Meshes: Record<string, Mesh> = {};
 
     Camera?: Camera;
     // The rendering pipeline supports 8 lights.

--- a/Monkey/index.ts
+++ b/Monkey/index.ts
@@ -7,10 +7,7 @@ let game = new Game();
 // @ts-ignore
 window.game = game;
 
-Promise.all([
-    load_mesh("monkey_flat").then(report_progress),
-    load_mesh("monkey_smooth").then(report_progress),
-]).then(() => {
+Promise.all([load_mesh("monkey_flat"), load_mesh("monkey_smooth")]).then(() => {
     scene_stage(game);
     loop_start(game);
 });
@@ -18,9 +15,7 @@ Promise.all([
 async function load_mesh(name: string) {
     let module = await import("../meshes/" + name + ".js");
     game.Meshes[name] = module["mesh_" + name](game.Gl);
-    return name;
-}
 
-function report_progress(name: string) {
+    // Report loading progress.
     game.Ui.innerHTML += `Loading <code>${name}</code>... ✓<br>`;
 }

--- a/Monkey/index.ts
+++ b/Monkey/index.ts
@@ -3,8 +3,24 @@ import {Game} from "./game.js";
 import {scene_stage} from "./scenes/sce_stage.js";
 
 let game = new Game();
-scene_stage(game);
-loop_start(game);
 
 // @ts-ignore
 window.game = game;
+
+Promise.all([
+    load_mesh("monkey_flat").then(report_progress),
+    load_mesh("monkey_smooth").then(report_progress),
+]).then(() => {
+    scene_stage(game);
+    loop_start(game);
+});
+
+async function load_mesh(name: string) {
+    let module = await import("../meshes/" + name + ".js");
+    game.Meshes[name] = module["mesh_" + name](game.Gl);
+    return name;
+}
+
+function report_progress(name: string) {
+    game.Ui.innerHTML += `Loading <code>${name}</code>... ✓<br>`;
+}

--- a/Monkey/scenes/sce_stage.ts
+++ b/Monkey/scenes/sce_stage.ts
@@ -33,14 +33,21 @@ export function scene_stage(game: Game) {
     // Flat.
     instantiate(game, {
         Translation: [-0.7, 0.5, 0],
-        Using: [render_diffuse(game.MaterialDiffuseGouraud, game.MeshMonkeyFlat, [1, 1, 0.3, 1])],
+        Using: [
+            render_diffuse(game.MaterialDiffuseGouraud, game.Meshes["monkey_flat"], [1, 1, 0.3, 1]),
+        ],
     });
 
     // Phong.
     instantiate(game, {
         Translation: [0.7, -0.5, 0],
         Using: [
-            render_specular(game.MaterialSpecularPhong, game.MeshMonkeySmooth, [1, 1, 0.3, 1], 64),
+            render_specular(
+                game.MaterialSpecularPhong,
+                game.Meshes["monkey_smooth"],
+                [1, 1, 0.3, 1],
+                64
+            ),
         ],
     });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
             "ES2019",
             "DOM",
         ],
-        "module": "es2015",
+        "module": "es2020",
         "moduleResolution": "node",
         "strict": true,
         "sourceMap": true


### PR DESCRIPTION
ES2020 introduces the `import()` built-in which may be used to import modules dynamically. This can be used to defer loading big data files, like meshes, and to report loading progress, too.