### PR TITLE
Layers for collision detection

### DIFF
--- a/PathFinding/components/com_collide.ts
+++ b/PathFinding/components/com_collide.ts
@@ -8,7 +8,7 @@ export interface Collide extends AABB {
     New: boolean;
     Dynamic: boolean;
     Layers: Layer;
-    Receives: Layer;
+    Mask: Layer;
     Collisions: Array<Collision>;
 }
 
@@ -17,11 +17,11 @@ export interface Collide extends AABB {
  *
  * @param dynamic Dynamic colliders collider with all colliders. Static
  * colliders collide only with dynamic colliders.
- * @param layers Bit mask with layers this collider is on.
- * @param receives Bit mask with layers visible to this collider.
+ * @param layers Bit field with layers this collider is on.
+ * @param Mask Bit mask with layers visible to this collider.
  * @param size Size of the collider relative to the entity's transform.
  */
-export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: Vec3 = [1, 1, 1]) {
+export function collide(dynamic: boolean, layers: Layer, Mask: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         game.World.Mask[entity] |= Has.Collide;
         game.World.Collide[entity] = {
@@ -29,7 +29,7 @@ export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: 
             New: true,
             Dynamic: dynamic,
             Layers: layers,
-            Receives: receives,
+            Mask: Mask,
             Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],

--- a/PathFinding/components/com_collide.ts
+++ b/PathFinding/components/com_collide.ts
@@ -1,28 +1,36 @@
 import {AABB} from "../../common/aabb.js";
 import {Vec3} from "../../common/math.js";
-import {Entity, Game} from "../game.js";
+import {Entity, Game, Layer} from "../game.js";
 import {Has} from "../world.js";
 
 export interface Collide extends AABB {
     readonly Entity: Entity;
     New: boolean;
-    /**
-     * Dynamic colliders collide with all colliders. Static colliders collide
-     * only with dynamic colliders.
-     */
     Dynamic: boolean;
-    /** Collisions detected with this collider during this tick. */
+    Layers: Layer;
+    Receives: Layer;
     Collisions: Array<Collision>;
 }
 
-export function collide(Dynamic: boolean = true, Size: [number, number, number] = [1, 1, 1]) {
+/**
+ * Add the Collide component.
+ *
+ * @param dynamic Dynamic colliders collider with all colliders. Static
+ * colliders collide only with dynamic colliders.
+ * @param layers Bit mask with layers this collider is on.
+ * @param receives Bit mask with layers visible to this collider.
+ * @param size Size of the collider relative to the entity's transform.
+ */
+export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         game.World.Mask[entity] |= Has.Collide;
         game.World.Collide[entity] = {
             Entity: entity,
             New: true,
-            Dynamic,
-            Size,
+            Dynamic: dynamic,
+            Layers: layers,
+            Receives: receives,
+            Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],
             Center: [0, 0, 0],

--- a/PathFinding/game.ts
+++ b/PathFinding/game.ts
@@ -105,3 +105,7 @@ export class Game {
         sys_framerate(this, delta, performance.now() - now);
     }
 }
+
+export const enum Layer {
+    None = 0,
+}

--- a/PathFinding/scenes/sce_stage.ts
+++ b/PathFinding/scenes/sce_stage.ts
@@ -11,7 +11,7 @@ import {render_basic} from "../components/com_render_basic.js";
 import {render_diffuse} from "../components/com_render_diffuse.js";
 import {selectable} from "../components/com_selectable.js";
 import {instantiate} from "../core.js";
-import {Game} from "../game.js";
+import {Game, Layer} from "../game.js";
 import {nav_bake} from "../navmesh.js";
 import {Has, World} from "../world.js";
 
@@ -40,7 +40,7 @@ export function scene_stage(game: Game) {
         Using: [
             render_diffuse(game.MaterialDiffuseGouraud, game.MeshTerrain, [0.3, 0.3, 0.8, 1]),
             pickable(game.MeshTerrain),
-            collide(false, [100, 1, 100]),
+            collide(false, Layer.None, Layer.None, [100, 1, 100]),
         ],
         Children: [
             {
@@ -71,7 +71,7 @@ export function scene_stage(game: Game) {
             control_player(),
             pickable(),
             selectable(),
-            collide(true, [2, 2, 2]),
+            collide(true, Layer.None, Layer.None, [2, 2, 2]),
             // The origin node must match the entity's translation.
             nav_agent(nav, 190),
             move(10, 10),
@@ -96,7 +96,7 @@ export function scene_stage(game: Game) {
             control_player(),
             pickable(),
             selectable(),
-            collide(true, [2, 2, 2]),
+            collide(true, Layer.None, Layer.None, [2, 2, 2]),
             // The origin node must match the entity's translation.
             nav_agent(nav, 89),
             move(15, 15),

--- a/PathFinding/systems/sys_collide.ts
+++ b/PathFinding/systems/sys_collide.ts
@@ -51,8 +51,8 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        let collider_can_intersect = collider.Receives & other.Layers;
-        let other_can_intersect = other.Receives & collider.Layers;
+        let collider_can_intersect = collider.Mask & other.Layers;
+        let other_can_intersect = other.Mask & collider.Layers;
         if (collider_can_intersect || other_can_intersect) {
             if (intersect_aabb(collider, other)) {
                 let hit = penetrate_aabb(collider, other);

--- a/PathFinding/systems/sys_collide.ts
+++ b/PathFinding/systems/sys_collide.ts
@@ -51,16 +51,24 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        if (intersect_aabb(collider, other)) {
-            let hit = penetrate_aabb(collider, other);
-            collider.Collisions.push({
-                Other: other.Entity,
-                Hit: hit,
-            });
-            other.Collisions.push({
-                Other: collider.Entity,
-                Hit: negate([0, 0, 0], hit),
-            });
+        let collider_can_intersect = collider.Receives & other.Layers;
+        let other_can_intersect = other.Receives & collider.Layers;
+        if (collider_can_intersect || other_can_intersect) {
+            if (intersect_aabb(collider, other)) {
+                let hit = penetrate_aabb(collider, other);
+                if (collider_can_intersect) {
+                    collider.Collisions.push({
+                        Other: other.Entity,
+                        Hit: hit,
+                    });
+                }
+                if (other_can_intersect) {
+                    other.Collisions.push({
+                        Other: collider.Entity,
+                        Hit: negate([0, 0, 0], hit),
+                    });
+                }
+            }
         }
     }
 }

--- a/RigidBody/blueprints/blu_box.ts
+++ b/RigidBody/blueprints/blu_box.ts
@@ -3,13 +3,13 @@ import {lifespan} from "../components/com_lifespan.js";
 import {render_diffuse} from "../components/com_render_diffuse.js";
 import {rigid_body} from "../components/com_rigid_body.js";
 import {Blueprint} from "../core.js";
-import {Game} from "../game.js";
+import {Game, Layer} from "../game.js";
 
 export function blueprint_box(game: Game): Blueprint {
     return {
         Using: [
             render_diffuse(game.MaterialDiffuseGouraud, game.MeshCube, [1, 0.3, 0, 1]),
-            collide(true),
+            collide(true, Layer.Physics, Layer.Terrain | Layer.Physics),
             rigid_body(true),
             lifespan(7),
         ],

--- a/RigidBody/components/com_collide.ts
+++ b/RigidBody/components/com_collide.ts
@@ -1,28 +1,36 @@
 import {AABB} from "../../common/aabb.js";
 import {Vec3} from "../../common/math.js";
-import {Entity, Game} from "../game.js";
+import {Entity, Game, Layer} from "../game.js";
 import {Has} from "../world.js";
 
 export interface Collide extends AABB {
     readonly Entity: Entity;
     New: boolean;
-    /**
-     * Dynamic colliders collide with all colliders. Static colliders collide
-     * only with dynamic colliders.
-     */
     Dynamic: boolean;
-    /** Collisions detected with this collider during this tick. */
+    Layers: Layer;
+    Receives: Layer;
     Collisions: Array<Collision>;
 }
 
-export function collide(Dynamic: boolean = true, Size: [number, number, number] = [1, 1, 1]) {
+/**
+ * Add the Collide component.
+ *
+ * @param dynamic Dynamic colliders collider with all colliders. Static
+ * colliders collide only with dynamic colliders.
+ * @param layers Bit mask with layers this collider is on.
+ * @param receives Bit mask with layers visible to this collider.
+ * @param size Size of the collider relative to the entity's transform.
+ */
+export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         game.World.Mask[entity] |= Has.Collide;
         game.World.Collide[entity] = {
             Entity: entity,
             New: true,
-            Dynamic,
-            Size,
+            Dynamic: dynamic,
+            Layers: layers,
+            Receives: receives,
+            Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],
             Center: [0, 0, 0],

--- a/RigidBody/components/com_collide.ts
+++ b/RigidBody/components/com_collide.ts
@@ -8,7 +8,7 @@ export interface Collide extends AABB {
     New: boolean;
     Dynamic: boolean;
     Layers: Layer;
-    Receives: Layer;
+    Mask: Layer;
     Collisions: Array<Collision>;
 }
 
@@ -17,11 +17,11 @@ export interface Collide extends AABB {
  *
  * @param dynamic Dynamic colliders collider with all colliders. Static
  * colliders collide only with dynamic colliders.
- * @param layers Bit mask with layers this collider is on.
- * @param receives Bit mask with layers visible to this collider.
+ * @param layers Bit field with layers this collider is on.
+ * @param mask Bit mask with layers visible to this collider.
  * @param size Size of the collider relative to the entity's transform.
  */
-export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: Vec3 = [1, 1, 1]) {
+export function collide(dynamic: boolean, layers: Layer, mask: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         game.World.Mask[entity] |= Has.Collide;
         game.World.Collide[entity] = {
@@ -29,7 +29,7 @@ export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: 
             New: true,
             Dynamic: dynamic,
             Layers: layers,
-            Receives: receives,
+            Mask: mask,
             Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],

--- a/RigidBody/game.ts
+++ b/RigidBody/game.ts
@@ -68,3 +68,9 @@ export class Game {
         sys_framerate(this, delta, performance.now() - now);
     }
 }
+
+export const enum Layer {
+    None = 0,
+    Terrain = 1,
+    Physics = 2,
+}

--- a/RigidBody/scenes/sce_stage.ts
+++ b/RigidBody/scenes/sce_stage.ts
@@ -5,7 +5,7 @@ import {light_directional} from "../components/com_light.js";
 import {render_diffuse} from "../components/com_render_diffuse.js";
 import {rigid_body} from "../components/com_rigid_body.js";
 import {instantiate} from "../core.js";
-import {Game} from "../game.js";
+import {Game, Layer} from "../game.js";
 import {World} from "../world.js";
 
 export function scene_stage(game: Game) {
@@ -32,7 +32,7 @@ export function scene_stage(game: Game) {
         Scale: [10, 1, 10],
         Using: [
             render_diffuse(game.MaterialDiffuseGouraud, game.MeshCube, [1, 1, 0.3, 1]),
-            collide(false),
+            collide(false, Layer.Terrain, Layer.None),
             rigid_body(false),
         ],
     });

--- a/RigidBody/systems/sys_collide.ts
+++ b/RigidBody/systems/sys_collide.ts
@@ -51,8 +51,8 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        let collider_can_intersect = collider.Receives & other.Layers;
-        let other_can_intersect = other.Receives & collider.Layers;
+        let collider_can_intersect = collider.Mask & other.Layers;
+        let other_can_intersect = other.Mask & collider.Layers;
         if (collider_can_intersect || other_can_intersect) {
             if (intersect_aabb(collider, other)) {
                 let hit = penetrate_aabb(collider, other);

--- a/RigidBody/systems/sys_collide.ts
+++ b/RigidBody/systems/sys_collide.ts
@@ -51,16 +51,24 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        if (intersect_aabb(collider, other)) {
-            let hit = penetrate_aabb(collider, other);
-            collider.Collisions.push({
-                Other: other.Entity,
-                Hit: hit,
-            });
-            other.Collisions.push({
-                Other: collider.Entity,
-                Hit: negate([0, 0, 0], hit),
-            });
+        let collider_can_intersect = collider.Receives & other.Layers;
+        let other_can_intersect = other.Receives & collider.Layers;
+        if (collider_can_intersect || other_can_intersect) {
+            if (intersect_aabb(collider, other)) {
+                let hit = penetrate_aabb(collider, other);
+                if (collider_can_intersect) {
+                    collider.Collisions.push({
+                        Other: other.Entity,
+                        Hit: hit,
+                    });
+                }
+                if (other_can_intersect) {
+                    other.Collisions.push({
+                        Other: collider.Entity,
+                        Hit: negate([0, 0, 0], hit),
+                    });
+                }
+            }
         }
     }
 }

--- a/ThirdPerson/blueprints/blu_ground.ts
+++ b/ThirdPerson/blueprints/blu_ground.ts
@@ -3,12 +3,12 @@ import {collide} from "../components/com_collide.js";
 import {render_diffuse} from "../components/com_render_diffuse.js";
 import {rigid_body} from "../components/com_rigid_body.js";
 import {Blueprint} from "../core.js";
-import {Game} from "../game.js";
+import {Game, Layer} from "../game.js";
 
 export function blueprint_ground(game: Game, size: number): Blueprint {
     return {
         Scale: [size, 1, size],
-        Using: [collide(false), rigid_body(false)],
+        Using: [collide(false, Layer.Terrain, Layer.None), rigid_body(false)],
         Children: [
             {
                 Translation: [0, float(-0.2, 0.2), 0],

--- a/ThirdPerson/blueprints/blu_player.ts
+++ b/ThirdPerson/blueprints/blu_player.ts
@@ -6,12 +6,17 @@ import {named} from "../components/com_named.js";
 import {render_diffuse} from "../components/com_render_diffuse.js";
 import {rigid_body} from "../components/com_rigid_body.js";
 import {Blueprint} from "../core.js";
-import {Game} from "../game.js";
+import {Game, Layer} from "../game.js";
 
 export function blueprint_player(game: Game): Blueprint {
     return {
         Rotation: [0, 1, 0, 0],
-        Using: [control_player(true, 0.2, 0), move(10, Infinity), collide(true), rigid_body(true)],
+        Using: [
+            control_player(true, 0.2, 0),
+            move(10, Infinity),
+            collide(true, Layer.Player, Layer.Terrain),
+            rigid_body(true),
+        ],
         Children: [
             {
                 // Body.

--- a/ThirdPerson/components/com_collide.ts
+++ b/ThirdPerson/components/com_collide.ts
@@ -1,37 +1,36 @@
+import {AABB} from "../../common/aabb.js";
 import {Vec3} from "../../common/math.js";
-import {Entity, Game} from "../game.js";
+import {Entity, Game, Layer} from "../game.js";
 import {Has} from "../world.js";
 
-export interface Collide {
+export interface Collide extends AABB {
     readonly Entity: Entity;
     New: boolean;
-    /**
-     * Dynamic colliders collide with all colliders. Static colliders collide
-     * only with dynamic colliders.
-     */
     Dynamic: boolean;
-    /** The size of the collider in self units. */
-    Size: [number, number, number];
-    /** The min corner of the AABB. */
-    Min: Vec3;
-    /** The max corner of the AABB. */
-    Max: Vec3;
-    /** The world position of the AABB. */
-    Center: Vec3;
-    /** The half-extents of the AABB on the three axes. */
-    Half: [number, number, number];
-    /** Collisions detected with this collider during this tick. */
+    Layers: Layer;
+    Receives: Layer;
     Collisions: Array<Collision>;
 }
 
-export function collide(Dynamic: boolean = true, Size: [number, number, number] = [1, 1, 1]) {
+/**
+ * Add the Collide component.
+ *
+ * @param dynamic Dynamic colliders collider with all colliders. Static
+ * colliders collide only with dynamic colliders.
+ * @param layers Bit mask with layers this collider is on.
+ * @param receives Bit mask with layers visible to this collider.
+ * @param size Size of the collider relative to the entity's transform.
+ */
+export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         game.World.Mask[entity] |= Has.Collide;
         game.World.Collide[entity] = {
             Entity: entity,
             New: true,
-            Dynamic,
-            Size,
+            Dynamic: dynamic,
+            Layers: layers,
+            Receives: receives,
+            Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],
             Center: [0, 0, 0],

--- a/ThirdPerson/components/com_collide.ts
+++ b/ThirdPerson/components/com_collide.ts
@@ -8,7 +8,7 @@ export interface Collide extends AABB {
     New: boolean;
     Dynamic: boolean;
     Layers: Layer;
-    Receives: Layer;
+    Mask: Layer;
     Collisions: Array<Collision>;
 }
 
@@ -17,11 +17,11 @@ export interface Collide extends AABB {
  *
  * @param dynamic Dynamic colliders collider with all colliders. Static
  * colliders collide only with dynamic colliders.
- * @param layers Bit mask with layers this collider is on.
- * @param receives Bit mask with layers visible to this collider.
+ * @param layers Bit field with layers this collider is on.
+ * @param mask Bit mask with layers visible to this collider.
  * @param size Size of the collider relative to the entity's transform.
  */
-export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: Vec3 = [1, 1, 1]) {
+export function collide(dynamic: boolean, layers: Layer, mask: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         game.World.Mask[entity] |= Has.Collide;
         game.World.Collide[entity] = {
@@ -29,7 +29,7 @@ export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: 
             New: true,
             Dynamic: dynamic,
             Layers: layers,
-            Receives: receives,
+            Mask: mask,
             Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],

--- a/ThirdPerson/game.ts
+++ b/ThirdPerson/game.ts
@@ -109,3 +109,8 @@ export class Game {
         sys_framerate(this, delta, performance.now() - now);
     }
 }
+export const enum Layer {
+    None = 0,
+    Player = 1,
+    Terrain = 2,
+}

--- a/ThirdPerson/systems/sys_collide.ts
+++ b/ThirdPerson/systems/sys_collide.ts
@@ -51,8 +51,8 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        let collider_can_intersect = collider.Receives & other.Layers;
-        let other_can_intersect = other.Receives & collider.Layers;
+        let collider_can_intersect = collider.Mask & other.Layers;
+        let other_can_intersect = other.Mask & collider.Layers;
         if (collider_can_intersect || other_can_intersect) {
             if (intersect_aabb(collider, other)) {
                 let hit = penetrate_aabb(collider, other);

--- a/ThirdPerson/systems/sys_collide.ts
+++ b/ThirdPerson/systems/sys_collide.ts
@@ -1,8 +1,6 @@
-import {get_translation} from "../../common/mat4.js";
-import {Vec3} from "../../common/math.js";
-import {negate, transform_point} from "../../common/vec3.js";
+import {compute_aabb, intersect_aabb, penetrate_aabb} from "../../common/aabb.js";
+import {negate} from "../../common/vec3.js";
 import {Collide} from "../components/com_collide.js";
-import {Transform} from "../components/com_transform.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
 
@@ -21,9 +19,9 @@ export function sys_collide(game: Game, delta: number) {
             collider.Collisions = [];
             if (collider.New) {
                 collider.New = false;
-                compute_aabb(transform, collider);
+                compute_aabb(transform.World, collider);
             } else if (collider.Dynamic) {
-                compute_aabb(transform, collider);
+                compute_aabb(transform.World, collider);
                 dynamic_colliders.push(collider);
             } else {
                 static_colliders.push(collider);
@@ -53,108 +51,24 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        if (intersect_aabb(collider, other)) {
-            let hit = penetrate_aabb(collider, other);
-            collider.Collisions.push({
-                Other: other.Entity,
-                Hit: hit,
-            });
-            other.Collisions.push({
-                Other: collider.Entity,
-                Hit: negate([0, 0, 0], hit),
-            });
+        let collider_can_intersect = collider.Receives & other.Layers;
+        let other_can_intersect = other.Receives & collider.Layers;
+        if (collider_can_intersect || other_can_intersect) {
+            if (intersect_aabb(collider, other)) {
+                let hit = penetrate_aabb(collider, other);
+                if (collider_can_intersect) {
+                    collider.Collisions.push({
+                        Other: other.Entity,
+                        Hit: hit,
+                    });
+                }
+                if (other_can_intersect) {
+                    other.Collisions.push({
+                        Other: collider.Entity,
+                        Hit: negate([0, 0, 0], hit),
+                    });
+                }
+            }
         }
     }
-}
-
-const BOX = [
-    [0.5, 0.5, 0.5],
-    [0.5, 0.5, -0.5],
-    [-0.5, 0.5, -0.5],
-    [-0.5, 0.5, 0.5],
-    [0.5, -0.5, 0.5],
-    [0.5, -0.5, -0.5],
-    [-0.5, -0.5, -0.5],
-    [-0.5, -0.5, 0.5],
-];
-
-function compute_aabb(transform: Transform, collide: Collide) {
-    get_translation(collide.Center, transform.World);
-
-    // Start with the extents on each axis set to the position of the center.
-    let min_x, min_y, min_z, max_x, max_y, max_z;
-    min_x = max_x = collide.Center[0];
-    min_y = max_y = collide.Center[1];
-    min_z = max_z = collide.Center[2];
-
-    // Expand the extents outwards from the center by finding the farthest
-    // vertex on each axis in both the negative and the positive direction.
-    let world_vertex = <Vec3>[0, 0, 0];
-    for (let i = 0; i < 8; i++) {
-        let bb_vertex = BOX[i];
-
-        // Scale the bounding box according to the size of the collider.
-        world_vertex[0] = bb_vertex[0] * collide.Size[0];
-        world_vertex[1] = bb_vertex[1] * collide.Size[1];
-        world_vertex[2] = bb_vertex[2] * collide.Size[2];
-
-        transform_point(world_vertex, world_vertex, transform.World);
-        if (world_vertex[0] < min_x) {
-            min_x = world_vertex[0];
-        }
-        if (world_vertex[0] > max_x) {
-            max_x = world_vertex[0];
-        }
-        if (world_vertex[1] < min_y) {
-            min_y = world_vertex[1];
-        }
-        if (world_vertex[1] > max_y) {
-            max_y = world_vertex[1];
-        }
-        if (world_vertex[2] < min_z) {
-            min_z = world_vertex[2];
-        }
-        if (world_vertex[2] > max_z) {
-            max_z = world_vertex[2];
-        }
-    }
-
-    // Save the min and max bounds.
-    collide.Min = [min_x, min_y, min_z];
-    collide.Max = [max_x, max_y, max_z];
-
-    // Calculate the half-extents.
-    collide.Half[0] = (max_x - min_x) / 2;
-    collide.Half[1] = (max_y - min_y) / 2;
-    collide.Half[2] = (max_z - min_z) / 2;
-}
-
-function penetrate_aabb(a: Collide, b: Collide) {
-    let distance_x = a.Center[0] - b.Center[0];
-    let penetration_x = a.Half[0] + b.Half[0] - Math.abs(distance_x);
-
-    let distance_y = a.Center[1] - b.Center[1];
-    let penetration_y = a.Half[1] + b.Half[1] - Math.abs(distance_y);
-
-    let distance_z = a.Center[2] - b.Center[2];
-    let penetration_z = a.Half[2] + b.Half[2] - Math.abs(distance_z);
-
-    if (penetration_x < penetration_y && penetration_x < penetration_z) {
-        return <Vec3>[penetration_x * Math.sign(distance_x), 0, 0];
-    } else if (penetration_y < penetration_z) {
-        return <Vec3>[0, penetration_y * Math.sign(distance_y), 0];
-    } else {
-        return <Vec3>[0, 0, penetration_z * Math.sign(distance_z)];
-    }
-}
-
-function intersect_aabb(a: Collide, b: Collide) {
-    return (
-        a.Min[0] < b.Max[0] &&
-        a.Max[0] > b.Min[0] &&
-        a.Min[1] < b.Max[1] &&
-        a.Max[1] > b.Min[1] &&
-        a.Min[2] < b.Max[2] &&
-        a.Max[2] > b.Min[2]
-    );
 }

--- a/Trigger/blueprints/blu_box.ts
+++ b/Trigger/blueprints/blu_box.ts
@@ -1,13 +1,13 @@
 import {collide} from "../components/com_collide.js";
 import {render_diffuse} from "../components/com_render_diffuse.js";
 import {Blueprint} from "../core.js";
-import {Game} from "../game.js";
+import {Game, Layer} from "../game.js";
 
 export function blueprint_box(game: Game): Blueprint {
     return {
         Using: [
             render_diffuse(game.MaterialDiffuseGouraud, game.MeshCube, [1, 1, 0.3, 1]),
-            collide(true),
+            collide(true, Layer.Default, Layer.None),
         ],
     };
 }

--- a/Trigger/components/com_collide.ts
+++ b/Trigger/components/com_collide.ts
@@ -1,28 +1,36 @@
 import {AABB} from "../../common/aabb.js";
 import {Vec3} from "../../common/math.js";
-import {Entity, Game} from "../game.js";
+import {Entity, Game, Layer} from "../game.js";
 import {Has} from "../world.js";
 
 export interface Collide extends AABB {
     readonly Entity: Entity;
     New: boolean;
-    /**
-     * Dynamic colliders collide with all colliders. Static colliders collide
-     * only with dynamic colliders.
-     */
     Dynamic: boolean;
-    /** Collisions detected with this collider during this tick. */
+    Layers: Layer;
+    Receives: Layer;
     Collisions: Array<Collision>;
 }
 
-export function collide(Dynamic: boolean = true, Size: [number, number, number] = [1, 1, 1]) {
+/**
+ * Add the Collide component.
+ *
+ * @param dynamic Dynamic colliders collider with all colliders. Static
+ * colliders collide only with dynamic colliders.
+ * @param layers Bit mask with layers this collider is on.
+ * @param receives Bit mask with layers visible to this collider.
+ * @param size Size of the collider relative to the entity's transform.
+ */
+export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         game.World.Mask[entity] |= Has.Collide;
         game.World.Collide[entity] = {
             Entity: entity,
             New: true,
-            Dynamic,
-            Size,
+            Dynamic: dynamic,
+            Layers: layers,
+            Receives: receives,
+            Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],
             Center: [0, 0, 0],

--- a/Trigger/components/com_collide.ts
+++ b/Trigger/components/com_collide.ts
@@ -8,7 +8,7 @@ export interface Collide extends AABB {
     New: boolean;
     Dynamic: boolean;
     Layers: Layer;
-    Receives: Layer;
+    Mask: Layer;
     Collisions: Array<Collision>;
 }
 
@@ -17,11 +17,11 @@ export interface Collide extends AABB {
  *
  * @param dynamic Dynamic colliders collider with all colliders. Static
  * colliders collide only with dynamic colliders.
- * @param layers Bit mask with layers this collider is on.
- * @param receives Bit mask with layers visible to this collider.
+ * @param layers Bit field with layers this collider is on.
+ * @param mask Bit mask with layers visible to this collider.
  * @param size Size of the collider relative to the entity's transform.
  */
-export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: Vec3 = [1, 1, 1]) {
+export function collide(dynamic: boolean, layers: Layer, mask: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         game.World.Mask[entity] |= Has.Collide;
         game.World.Collide[entity] = {
@@ -29,7 +29,7 @@ export function collide(dynamic: boolean, layers: Layer, receives: Layer, size: 
             New: true,
             Dynamic: dynamic,
             Layers: layers,
-            Receives: receives,
+            Mask: mask,
             Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],

--- a/Trigger/game.ts
+++ b/Trigger/game.ts
@@ -67,3 +67,8 @@ export class Game {
         sys_framerate(this, delta, performance.now() - now);
     }
 }
+
+export const enum Layer {
+    None = 0,
+    Default = 1 << 0,
+}

--- a/Trigger/scenes/sce_stage.ts
+++ b/Trigger/scenes/sce_stage.ts
@@ -6,7 +6,7 @@ import {light_directional} from "../components/com_light.js";
 import {rotate} from "../components/com_rotate.js";
 import {trigger} from "../components/com_trigger.js";
 import {instantiate} from "../core.js";
-import {Game} from "../game.js";
+import {Game, Layer} from "../game.js";
 import {World} from "../world.js";
 
 export function scene_stage(game: Game) {
@@ -41,6 +41,6 @@ export function scene_stage(game: Game) {
     // Trigger.
     instantiate(game, {
         Translation: [4, 0, 0],
-        Using: [collide(false), trigger(Action.Alert)],
+        Using: [collide(false, Layer.None, Layer.Default), trigger(Action.Alert)],
     });
 }

--- a/Trigger/systems/sys_collide.ts
+++ b/Trigger/systems/sys_collide.ts
@@ -51,8 +51,8 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        let collider_can_intersect = collider.Receives & other.Layers;
-        let other_can_intersect = other.Receives & collider.Layers;
+        let collider_can_intersect = collider.Mask & other.Layers;
+        let other_can_intersect = other.Mask & collider.Layers;
         if (collider_can_intersect || other_can_intersect) {
             if (intersect_aabb(collider, other)) {
                 let hit = penetrate_aabb(collider, other);

--- a/Trigger/systems/sys_collide.ts
+++ b/Trigger/systems/sys_collide.ts
@@ -51,16 +51,24 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        if (intersect_aabb(collider, other)) {
-            let hit = penetrate_aabb(collider, other);
-            collider.Collisions.push({
-                Other: other.Entity,
-                Hit: hit,
-            });
-            other.Collisions.push({
-                Other: collider.Entity,
-                Hit: negate([0, 0, 0], hit),
-            });
+        let collider_can_intersect = collider.Receives & other.Layers;
+        let other_can_intersect = other.Receives & collider.Layers;
+        if (collider_can_intersect || other_can_intersect) {
+            if (intersect_aabb(collider, other)) {
+                let hit = penetrate_aabb(collider, other);
+                if (collider_can_intersect) {
+                    collider.Collisions.push({
+                        Other: other.Entity,
+                        Hit: hit,
+                    });
+                }
+                if (other_can_intersect) {
+                    other.Collisions.push({
+                        Other: collider.Entity,
+                        Hit: negate([0, 0, 0], hit),
+                    });
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Our collision detection can be made asymmetric through the introduction of layers.

Collisions are stored in the entity's `Collide` component (in the `Collide.Collisions` array, which is emptied every frame). On master, two collision info objects are created for evey collision: one for each entity involved in the collision. Consequently, both entities "know" about the collision.

Layers allow controlling which collisions a collider will know about. A collider must define which layers it's on (`Collide.Layers`) as well as which layers are visible to it (`Collider.Receives`). Layers are defined as bit masks, and the creation of a collision info object is conditional on the outcome of a bit mask test. More specifically:

- If `collider.Receives & other.Layers` is truthy, the collision with `other` will be stored in `collider`'s `Collisions` array.
- If `other.Receives & collider.Layers` is truthy, the collision with `collider` will be stored in `other`'s `Collisions` array.

I'm not sure if `Receives` is the right name here, btw. Any ideas?
