### PR TITLE
(sys_animate) Don't queue triggers

### DIFF
--- a/Animate/systems/sys_animate.ts
+++ b/Animate/systems/sys_animate.ts
@@ -22,15 +22,17 @@ function update(game: Game, entity: Entity, delta: number) {
 
     if (animate.Trigger) {
         let next = animate.States[animate.Trigger];
-        if (
-            next &&
-            (animate.Current.Flags & AnimationFlag.EarlyExit || animate.Current.Time === 0)
-        ) {
-            // We don't reset the current state's timer because the trigger may be
-            // the same state as the current. If the states are different, this may
-            // result in clips not starting from the first keyframe, which should
-            // be generally OK for animations with EarlyExit.
-            animate.Current = next;
+        if (next && next !== animate.Current) {
+            if (animate.Current.Time === 0) {
+                // If the current clip has completed last frame, switch to the trigger.
+                animate.Current = next;
+            } else if (animate.Current.Flags & AnimationFlag.EarlyExit) {
+                // If the current clip allows early exits, reset its timer so
+                // that the next time it plays it starts from the beginning,
+                // and then switch to the trigger.
+                animate.Current.Time = 0;
+                animate.Current = next;
+            }
         }
         animate.Trigger = undefined;
     }
@@ -107,6 +109,5 @@ function update(game: Game, entity: Entity, delta: number) {
 
     if (!(animate.Current.Flags & AnimationFlag.Loop)) {
         animate.Current = animate.States["idle"];
-        animate.Current.Time = 0;
     }
 }

--- a/Animate/systems/sys_animate.ts
+++ b/Animate/systems/sys_animate.ts
@@ -18,15 +18,20 @@ function update(game: Game, entity: Entity, delta: number) {
     let transform = game.World.Transform[entity];
     let animate = game.World.Animate[entity];
 
-    // 1. Switch to the trigger this frame if early exits are allowed.
+    // 1. Switch to the trigger if the clip has completed or early exits are allowed.
 
-    let next = animate.Trigger && animate.States[animate.Trigger];
-    if (next && animate.Current.Flags & AnimationFlag.EarlyExit) {
-        // We don't reset the current state's timer because the trigger may be
-        // the same state as the current. If the states are different, this may
-        // result in clips not starting from the first keyframe, which should
-        // be generally OK for animations with EarlyExit.
-        animate.Current = next;
+    if (animate.Trigger) {
+        let next = animate.States[animate.Trigger];
+        if (
+            next &&
+            (animate.Current.Flags & AnimationFlag.EarlyExit || animate.Current.Time === 0)
+        ) {
+            // We don't reset the current state's timer because the trigger may be
+            // the same state as the current. If the states are different, this may
+            // result in clips not starting from the first keyframe, which should
+            // be generally OK for animations with EarlyExit.
+            animate.Current = next;
+        }
         animate.Trigger = undefined;
     }
 
@@ -91,7 +96,7 @@ function update(game: Game, entity: Entity, delta: number) {
         animate.Current.Time = 0;
     }
 
-    // 5. The animation has completed. Determine what to do next.
+    // 5. The animation has completed. Loop it or switch to idle.
 
     if (animate.Current.Flags & AnimationFlag.Alternate) {
         // Reverse the keyframes of the clip and recalculate their timestamps.
@@ -100,13 +105,8 @@ function update(game: Game, entity: Entity, delta: number) {
         }
     }
 
-    if (next) {
-        // Switch to the trigger. All clips can be exited from when they finish,
-        // regardless of the lack of the EarlyExit flag. The trigger may be the
-        // same state as the current.
-        animate.Current = next;
-        animate.Trigger = undefined;
-    } else if (!(animate.Current.Flags & AnimationFlag.Loop)) {
+    if (!(animate.Current.Flags & AnimationFlag.Loop)) {
         animate.Current = animate.States["idle"];
+        animate.Current.Time = 0;
     }
 }


### PR DESCRIPTION
The way in which `sys_animate` currently allows switching away from animation clips which have just completed also means that the `Trigger` is not cleared until it's switched _to_. In consequence, if the current clip doesn't allow early exits, the next clip is queued until the current one completes.

In this PR I remove this behavior and replace it with a more predictable model: clip can be switched either when the one currently playing has just completed (`animate.Current.Time === 0`) or when it allows early exits.