### PR TITLE
Rename World.Mask → World.Get

### DIFF
--- a/Animate/components/com_animate.ts
+++ b/Animate/components/com_animate.ts
@@ -29,7 +29,7 @@ export function animate(clips: {idle: AnimationClip; [k: string]: AnimationClip}
                 Time: 0,
             };
         }
-        game.World.Mask[entity] |= Has.Animate;
+        game.World.Get[entity] |= Has.Animate;
         game.World.Animate[entity] = {
             States,
             Current: States["idle"],

--- a/Animate/components/com_audio_source.ts
+++ b/Animate/components/com_audio_source.ts
@@ -20,7 +20,7 @@ export interface AudioSource {
  */
 export function audio_source(idle?: AudioClip) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.AudioSource;
+        game.World.Get[entity] |= Has.AudioSource;
         game.World.AudioSource[entity] = {
             Idle: idle,
             Time: 0,

--- a/Animate/components/com_camera.ts
+++ b/Animate/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/Animate/components/com_control.ts
+++ b/Animate/components/com_control.ts
@@ -3,6 +3,6 @@ import {Has} from "../world.js";
 
 export function control() {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Control;
+        game.World.Get[entity] |= Has.Control;
     };
 }

--- a/Animate/components/com_light.ts
+++ b/Animate/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/Animate/components/com_render_diffuse.ts
+++ b/Animate/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/Animate/components/com_transform.ts
+++ b/Animate/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/Animate/core.ts
+++ b/Animate/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/Animate/systems/sys_animate.ts
+++ b/Animate/systems/sys_animate.ts
@@ -7,8 +7,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Animate;
 
 export function sys_animate(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/Animate/systems/sys_audio.ts
+++ b/Animate/systems/sys_audio.ts
@@ -5,8 +5,8 @@ import {Has} from "../world.js";
 const QUERY = Has.AudioSource;
 
 export function sys_audio(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/Animate/systems/sys_camera.ts
+++ b/Animate/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/Animate/systems/sys_control.ts
+++ b/Animate/systems/sys_control.ts
@@ -8,8 +8,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Control | Has.AudioSource;
 
 export function sys_control(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Animate/systems/sys_light.ts
+++ b/Animate/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/Animate/systems/sys_render.ts
+++ b/Animate/systems/sys_render.ts
@@ -19,8 +19,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/Animate/systems/sys_transform.ts
+++ b/Animate/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Animate/world.ts
+++ b/Animate/world.ts
@@ -27,7 +27,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Animate: Array<Animate> = [];
     AudioSource: Array<AudioSource> = [];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
     ```js
     class World {
-        public Mask: Array<number> = [];
+        public Get: Array<number> = [];
         public Animate: Array<Animate> = [];
         public AudioSource: Array<AudioSource> = [];
         // ...
@@ -22,10 +22,10 @@
 - The `Get` enum has been removed.
 
 - Component checks are performed with bitwise operations between the
-`World.Mask` array and the `Has` enum.
+`World.Get` array and the `Has` enum.
 
     ```js
-    if (game.World.Mask[entity] & Has.Transform) ...
+    if (game.World.Get[entity] & Has.Transform) ...
     ```
 
 - Component data is retrieved from `game.World`.

--- a/FlatShading/components/com_camera.ts
+++ b/FlatShading/components/com_camera.ts
@@ -14,7 +14,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/FlatShading/components/com_light.ts
+++ b/FlatShading/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/FlatShading/components/com_render_diffuse.ts
+++ b/FlatShading/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/FlatShading/components/com_render_specular.ts
+++ b/FlatShading/components/com_render_specular.ts
@@ -53,7 +53,7 @@ export function render_specular(
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Specular,
             Material: material,

--- a/FlatShading/components/com_rotate.ts
+++ b/FlatShading/components/com_rotate.ts
@@ -9,7 +9,7 @@ export interface Rotate {
 
 export function rotate(rotation: Vec3) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Rotate;
+        game.World.Get[entity] |= Has.Rotate;
         game.World.Rotate[entity] = {
             Rotation: rotation,
         };

--- a/FlatShading/components/com_transform.ts
+++ b/FlatShading/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/FlatShading/core.ts
+++ b/FlatShading/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/FlatShading/systems/sys_camera.ts
+++ b/FlatShading/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/FlatShading/systems/sys_light.ts
+++ b/FlatShading/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/FlatShading/systems/sys_render.ts
+++ b/FlatShading/systems/sys_render.ts
@@ -21,8 +21,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/FlatShading/systems/sys_rotate.ts
+++ b/FlatShading/systems/sys_rotate.ts
@@ -6,8 +6,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Rotate;
 
 export function sys_rotate(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/FlatShading/systems/sys_transform.ts
+++ b/FlatShading/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/FlatShading/world.ts
+++ b/FlatShading/world.ts
@@ -22,7 +22,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Light: Array<Light> = [];

--- a/FlyCamera/components/com_camera.ts
+++ b/FlyCamera/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/FlyCamera/components/com_control_player.ts
+++ b/FlyCamera/components/com_control_player.ts
@@ -16,7 +16,7 @@ export interface ControlPlayer {
  */
 export function control_player(move: boolean, yaw: number, pitch: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.ControlPlayer;
+        game.World.Get[entity] |= Has.ControlPlayer;
         game.World.ControlPlayer[entity] = {
             Move: move,
             Yaw: yaw,

--- a/FlyCamera/components/com_draw.ts
+++ b/FlyCamera/components/com_draw.ts
@@ -15,7 +15,7 @@ export interface DrawMarker {
 
 export function draw_marker(Marker: string) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Draw;
+        game.World.Get[entity] |= Has.Draw;
         game.World.Draw[entity] = {
             Kind: DrawKind.Marker,
             Marker,

--- a/FlyCamera/components/com_light.ts
+++ b/FlyCamera/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/FlyCamera/components/com_move.ts
+++ b/FlyCamera/components/com_move.ts
@@ -25,7 +25,7 @@ export interface Move {
  */
 export function move(MoveSpeed: number, RotateSpeed: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Move;
+        game.World.Get[entity] |= Has.Move;
         game.World.Move[entity] = {
             MoveSpeed,
             RotateSpeed,

--- a/FlyCamera/components/com_render_diffuse.ts
+++ b/FlyCamera/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/FlyCamera/components/com_transform.ts
+++ b/FlyCamera/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/FlyCamera/core.ts
+++ b/FlyCamera/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/FlyCamera/systems/sys_camera.ts
+++ b/FlyCamera/systems/sys_camera.ts
@@ -14,8 +14,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/FlyCamera/systems/sys_control_player.ts
+++ b/FlyCamera/systems/sys_control_player.ts
@@ -8,8 +8,8 @@ const AXIS_X = <Vec3>[1, 0, 0];
 const AXIS_Y = <Vec3>[0, 1, 0];
 
 export function sys_control_player(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/FlyCamera/systems/sys_draw.ts
+++ b/FlyCamera/systems/sys_draw.ts
@@ -12,8 +12,8 @@ export function sys_draw(game: Game, delta: number) {
     game.Context2D.clearRect(0, 0, game.ViewportWidth, game.ViewportHeight);
     let position = <Vec3>[0, 0, 0];
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             // World position.
             get_translation(position, game.World.Transform[i].World);
             // NDC position.

--- a/FlyCamera/systems/sys_light.ts
+++ b/FlyCamera/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/FlyCamera/systems/sys_move.ts
+++ b/FlyCamera/systems/sys_move.ts
@@ -14,8 +14,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Move;
 
 export function sys_move(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/FlyCamera/systems/sys_render.ts
+++ b/FlyCamera/systems/sys_render.ts
@@ -19,8 +19,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/FlyCamera/systems/sys_transform.ts
+++ b/FlyCamera/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/FlyCamera/world.ts
+++ b/FlyCamera/world.ts
@@ -28,7 +28,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     ControlPlayer: Array<ControlPlayer> = [];

--- a/Instancing/components/com_camera.ts
+++ b/Instancing/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/Instancing/components/com_light.ts
+++ b/Instancing/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/Instancing/components/com_render_instanced.ts
+++ b/Instancing/components/com_render_instanced.ts
@@ -52,7 +52,7 @@ export function render_instanced(mesh: Mesh, offsets: Model, palette: Array<numb
         game.Gl.bindBuffer(GL_ELEMENT_ARRAY_BUFFER, mesh.IndexBuffer);
 
         game.Gl.bindVertexArray(null);
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Instanced,
             Material: material,

--- a/Instancing/components/com_transform.ts
+++ b/Instancing/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/Instancing/core.ts
+++ b/Instancing/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/Instancing/systems/sys_camera.ts
+++ b/Instancing/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/Instancing/systems/sys_light.ts
+++ b/Instancing/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/Instancing/systems/sys_render.ts
+++ b/Instancing/systems/sys_render.ts
@@ -19,8 +19,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/Instancing/systems/sys_transform.ts
+++ b/Instancing/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Instancing/world.ts
+++ b/Instancing/world.ts
@@ -19,7 +19,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Light: Array<Light> = [];

--- a/Monkey/components/com_camera.ts
+++ b/Monkey/components/com_camera.ts
@@ -14,7 +14,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/Monkey/components/com_light.ts
+++ b/Monkey/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/Monkey/components/com_render_diffuse.ts
+++ b/Monkey/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/Monkey/components/com_render_specular.ts
+++ b/Monkey/components/com_render_specular.ts
@@ -53,7 +53,7 @@ export function render_specular(
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Specular,
             Material: material,

--- a/Monkey/components/com_transform.ts
+++ b/Monkey/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/Monkey/core.ts
+++ b/Monkey/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/Monkey/systems/sys_camera.ts
+++ b/Monkey/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/Monkey/systems/sys_light.ts
+++ b/Monkey/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/Monkey/systems/sys_render.ts
+++ b/Monkey/systems/sys_render.ts
@@ -21,8 +21,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/Monkey/systems/sys_transform.ts
+++ b/Monkey/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Monkey/world.ts
+++ b/Monkey/world.ts
@@ -19,7 +19,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Light: Array<Light> = [];

--- a/NewProject2D/components/com_draw.ts
+++ b/NewProject2D/components/com_draw.ts
@@ -16,7 +16,7 @@ export interface DrawRect {
 
 export function draw_rect(Width: number, Height: number, Color: string) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Draw;
+        game.World.Get[entity] |= Has.Draw;
         game.World.Draw[entity] = {
             Kind: DrawKind.Rect,
             Width,

--- a/NewProject2D/components/com_transform2d.ts
+++ b/NewProject2D/components/com_transform2d.ts
@@ -21,7 +21,7 @@ export interface Transform2D {
 
 export function transform2d(Translation: Vec2 = [0, 0], Rotation: Rad = 0, Scale: Vec2 = [1, 1]) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform2D;
+        game.World.Get[entity] |= Has.Transform2D;
         game.World.Transform2D[entity] = {
             World: create(),
             Self: create(),
@@ -43,7 +43,7 @@ export function transform2d(Translation: Vec2 = [0, 0], Rotation: Rad = 0, Scale
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform2D[parent].Children) {

--- a/NewProject2D/core.ts
+++ b/NewProject2D/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform2D) {
         for (let child of world.Transform2D[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/NewProject2D/systems/sys_draw2d.ts
+++ b/NewProject2D/systems/sys_draw2d.ts
@@ -9,8 +9,8 @@ export function sys_draw2d(game: Game, delta: number) {
     game.Context2D.fillStyle = "#e6e6e6";
     game.Context2D.fillRect(0, 0, game.ViewportWidth, game.ViewportHeight);
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             let transform = game.World.Transform2D[i];
             game.Context2D.setTransform(
                 transform.World[0],

--- a/NewProject2D/systems/sys_transform2d.ts
+++ b/NewProject2D/systems/sys_transform2d.ts
@@ -5,8 +5,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform2D;
 
 export function sys_transform2d(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/NewProject2D/world.ts
+++ b/NewProject2D/world.ts
@@ -13,7 +13,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Draw: Array<Draw> = [];
     Transform2D: Array<Transform2D> = [];

--- a/NewProject3D/components/com_camera.ts
+++ b/NewProject3D/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/NewProject3D/components/com_light.ts
+++ b/NewProject3D/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/NewProject3D/components/com_render_diffuse.ts
+++ b/NewProject3D/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/NewProject3D/components/com_transform.ts
+++ b/NewProject3D/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/NewProject3D/core.ts
+++ b/NewProject3D/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/NewProject3D/systems/sys_camera.ts
+++ b/NewProject3D/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/NewProject3D/systems/sys_light.ts
+++ b/NewProject3D/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/NewProject3D/systems/sys_render.ts
+++ b/NewProject3D/systems/sys_render.ts
@@ -19,8 +19,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/NewProject3D/systems/sys_transform.ts
+++ b/NewProject3D/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/NewProject3D/world.ts
+++ b/NewProject3D/world.ts
@@ -19,7 +19,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Light: Array<Light> = [];

--- a/Particles/components/com_camera.ts
+++ b/Particles/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/Particles/components/com_emit_particles.ts
+++ b/Particles/components/com_emit_particles.ts
@@ -16,7 +16,7 @@ export interface EmitParticles {
  */
 export function emit_particles(Lifespan: number, Frequency: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.EmitParticles;
+        game.World.Get[entity] |= Has.EmitParticles;
         game.World.EmitParticles[entity] = {
             Lifespan,
             Frequency,

--- a/Particles/components/com_render_particles.ts
+++ b/Particles/components/com_render_particles.ts
@@ -20,7 +20,7 @@ export function render_particles(
     end_size: number
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Particles,
             Material: game.MaterialParticles,

--- a/Particles/components/com_shake.ts
+++ b/Particles/components/com_shake.ts
@@ -10,7 +10,7 @@ export interface Shake {
  */
 export function shake(Duration = 0) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Shake;
+        game.World.Get[entity] |= Has.Shake;
         game.World.Shake[entity] = {
             Duration,
         };

--- a/Particles/components/com_transform.ts
+++ b/Particles/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/Particles/core.ts
+++ b/Particles/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/Particles/systems/sys_camera.ts
+++ b/Particles/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/Particles/systems/sys_particles.ts
+++ b/Particles/systems/sys_particles.ts
@@ -6,8 +6,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.EmitParticles;
 
 export function sys_particles(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             update(game, i, delta);
         }
     }

--- a/Particles/systems/sys_render.ts
+++ b/Particles/systems/sys_render.ts
@@ -24,8 +24,8 @@ export function sys_render(game: Game, delta: number) {
     // Keep track of the current material to minimize switching.
     let current_material = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let render = game.World.Render[i];
 
             if (render.Material !== current_material) {

--- a/Particles/systems/sys_shake.ts
+++ b/Particles/systems/sys_shake.ts
@@ -4,8 +4,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Shake;
 
 export function sys_shake(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             update(game, i, delta);
         }
     }

--- a/Particles/systems/sys_transform.ts
+++ b/Particles/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Particles/world.ts
+++ b/Particles/world.ts
@@ -22,7 +22,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     EmitParticles: Array<EmitParticles> = [];

--- a/PathFinding/components/com_camera.ts
+++ b/PathFinding/components/com_camera.ts
@@ -14,7 +14,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/PathFinding/components/com_collide.ts
+++ b/PathFinding/components/com_collide.ts
@@ -8,7 +8,7 @@ export interface Collide extends AABB {
     New: boolean;
     Dynamic: boolean;
     Layers: Layer;
-    Mask: Layer;
+    Get: Layer;
     Collisions: Array<Collision>;
 }
 
@@ -18,18 +18,18 @@ export interface Collide extends AABB {
  * @param dynamic Dynamic colliders collider with all colliders. Static
  * colliders collide only with dynamic colliders.
  * @param layers Bit field with layers this collider is on.
- * @param Mask Bit mask with layers visible to this collider.
+ * @param Get Bit mask with layers visible to this collider.
  * @param size Size of the collider relative to the entity's transform.
  */
-export function collide(dynamic: boolean, layers: Layer, Mask: Layer, size: Vec3 = [1, 1, 1]) {
+export function collide(dynamic: boolean, layers: Layer, Get: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Collide;
+        game.World.Get[entity] |= Has.Collide;
         game.World.Collide[entity] = {
             Entity: entity,
             New: true,
             Dynamic: dynamic,
             Layers: layers,
-            Mask: Mask,
+            Get: Get,
             Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],

--- a/PathFinding/components/com_control_player.ts
+++ b/PathFinding/components/com_control_player.ts
@@ -3,6 +3,6 @@ import {Has} from "../world.js";
 
 export function control_player() {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.ControlPlayer;
+        game.World.Get[entity] |= Has.ControlPlayer;
     };
 }

--- a/PathFinding/components/com_draw.ts
+++ b/PathFinding/components/com_draw.ts
@@ -15,7 +15,7 @@ export interface DrawText {
 
 export function draw_marker(Marker: string) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Draw;
+        game.World.Get[entity] |= Has.Draw;
         game.World.Draw[entity] = {
             Kind: DrawKind.Text,
             Text: Marker,
@@ -30,7 +30,7 @@ export interface DrawSelection {
 
 export function draw_selection(color: string) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Draw;
+        game.World.Get[entity] |= Has.Draw;
         game.World.Draw[entity] = {
             Kind: DrawKind.Selection,
             Color: color,

--- a/PathFinding/components/com_light.ts
+++ b/PathFinding/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/PathFinding/components/com_move.ts
+++ b/PathFinding/components/com_move.ts
@@ -25,7 +25,7 @@ export interface Move {
  */
 export function move(MoveSpeed: number, RotateSpeed: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Move;
+        game.World.Get[entity] |= Has.Move;
         game.World.Move[entity] = {
             MoveSpeed,
             RotateSpeed,

--- a/PathFinding/components/com_nav_agent.ts
+++ b/PathFinding/components/com_nav_agent.ts
@@ -24,7 +24,7 @@ export interface NavDestination {
  */
 export function nav_agent(navmesh: NavMesh, origin: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.NavAgent;
+        game.World.Get[entity] |= Has.NavAgent;
         game.World.NavAgent[entity] = {
             NavMesh: navmesh,
             Origin: origin,

--- a/PathFinding/components/com_pick.ts
+++ b/PathFinding/components/com_pick.ts
@@ -3,6 +3,6 @@ import {Has} from "../world.js";
 
 export function pick() {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Pick;
+        game.World.Get[entity] |= Has.Pick;
     };
 }

--- a/PathFinding/components/com_pickable.ts
+++ b/PathFinding/components/com_pickable.ts
@@ -8,7 +8,7 @@ export interface Pickable {
 
 export function pickable(mesh?: Mesh) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Pickable;
+        game.World.Get[entity] |= Has.Pickable;
         game.World.Pickable[entity] = {
             Mesh: mesh,
         };

--- a/PathFinding/components/com_render_basic.ts
+++ b/PathFinding/components/com_render_basic.ts
@@ -41,7 +41,7 @@ export function render_basic(material: Material<BasicLayout>, mesh: Mesh, color:
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Basic,
             Material: material,

--- a/PathFinding/components/com_render_diffuse.ts
+++ b/PathFinding/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/PathFinding/components/com_render_path.ts
+++ b/PathFinding/components/com_render_path.ts
@@ -21,7 +21,7 @@ export function render_path(max: number, color: Vec4) {
         game.Gl.bindBuffer(GL_ARRAY_BUFFER, vertex_buf);
         game.Gl.bufferData(GL_ARRAY_BUFFER, max * Float32Array.BYTES_PER_ELEMENT, GL_DYNAMIC_DRAW);
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Path,
             Material: game.MaterialBasicLine,

--- a/PathFinding/components/com_selectable.ts
+++ b/PathFinding/components/com_selectable.ts
@@ -8,7 +8,7 @@ export interface Selectable {
 
 export function selectable() {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Selectable;
+        game.World.Get[entity] |= Has.Selectable;
         game.World.Selectable[entity] = {
             Highlighted: false,
             Selected: false,

--- a/PathFinding/components/com_transform.ts
+++ b/PathFinding/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/PathFinding/core.ts
+++ b/PathFinding/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -56,7 +56,7 @@ export function instantiate(
         mixin(game, entity);
     }
     if (Disable) {
-        game.World.Mask[entity] &= ~Disable;
+        game.World.Get[entity] &= ~Disable;
     }
     let entity_transform = game.World.Transform[entity];
     for (let subtree of Children) {
@@ -69,11 +69,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/PathFinding/systems/sys_camera.ts
+++ b/PathFinding/systems/sys_camera.ts
@@ -14,8 +14,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/PathFinding/systems/sys_collide.ts
+++ b/PathFinding/systems/sys_collide.ts
@@ -10,8 +10,8 @@ export function sys_collide(game: Game, delta: number) {
     // Collect all colliders.
     let static_colliders: Collide[] = [];
     let dynamic_colliders: Collide[] = [];
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let collider = game.World.Collide[i];
 
@@ -51,8 +51,8 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        let collider_can_intersect = collider.Mask & other.Layers;
-        let other_can_intersect = other.Mask & collider.Layers;
+        let collider_can_intersect = collider.Get & other.Layers;
+        let other_can_intersect = other.Get & collider.Layers;
         if (collider_can_intersect || other_can_intersect) {
             if (intersect_aabb(collider, other)) {
                 let hit = penetrate_aabb(collider, other);

--- a/PathFinding/systems/sys_control_player.ts
+++ b/PathFinding/systems/sys_control_player.ts
@@ -18,11 +18,11 @@ export function sys_control_player(game: Game, delta: number) {
             Using: [render_path(512, [1, 1, 0, 1])],
         });
     }
-    game.World.Mask[line] &= ~Has.Render;
+    game.World.Get[line] &= ~Has.Render;
 
     if (game.Pick) {
-        for (let i = 0; i < game.World.Mask.length; i++) {
-            if ((game.World.Mask[i] & QUERY) == QUERY) {
+        for (let i = 0; i < game.World.Get.length; i++) {
+            if ((game.World.Get[i] & QUERY) == QUERY) {
                 update(game, i, game.Pick);
             }
         }
@@ -56,7 +56,7 @@ function update(game: Game, entity: Entity, pick: Picked) {
             // Add the entity's current position and the exact goal destination.
             waypoints = [world_pos, ...waypoints, pick.Point];
 
-            game.World.Mask[line] |= Has.Render;
+            game.World.Get[line] |= Has.Render;
             let render = game.World.Render[line] as RenderPath;
             render.IndexCount = waypoints.length;
             game.Gl.bindBuffer(GL_ARRAY_BUFFER, render.VertexBuffer);

--- a/PathFinding/systems/sys_draw.ts
+++ b/PathFinding/systems/sys_draw.ts
@@ -12,8 +12,8 @@ export function sys_draw(game: Game, delta: number) {
     game.Context2D.clearRect(0, 0, game.ViewportWidth, game.ViewportHeight);
     let position = <Vec3>[0, 0, 0];
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             // World position.
             get_translation(position, game.World.Transform[i].World);
             // NDC position.

--- a/PathFinding/systems/sys_light.ts
+++ b/PathFinding/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/PathFinding/systems/sys_move.ts
+++ b/PathFinding/systems/sys_move.ts
@@ -14,8 +14,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Move;
 
 export function sys_move(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/PathFinding/systems/sys_nav.ts
+++ b/PathFinding/systems/sys_nav.ts
@@ -9,8 +9,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.NavAgent | Has.Move;
 
 export function sys_nav(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             update(game, i);
         }
     }

--- a/PathFinding/systems/sys_pick.ts
+++ b/PathFinding/systems/sys_pick.ts
@@ -13,14 +13,14 @@ export function sys_pick(game: Game, delta: number) {
     game.Pick = undefined;
 
     let pickables: Array<Collide> = [];
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & TARGET) == TARGET) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & TARGET) == TARGET) {
             pickables.push(game.World.Collide[i]);
         }
     }
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             update(game, i, pickables);
         }
     }

--- a/PathFinding/systems/sys_render.ts
+++ b/PathFinding/systems/sys_render.ts
@@ -28,8 +28,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/PathFinding/systems/sys_select.ts
+++ b/PathFinding/systems/sys_select.ts
@@ -5,8 +5,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Selectable;
 
 export function sys_select(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             update(game, i);
         }
     }
@@ -29,11 +29,11 @@ function update(game: Game, entity: Entity) {
         // …select it if the user clicks.
         if (!selectable.Selected && game.InputDelta["Mouse0"] === -1) {
             selectable.Selected = true;
-            game.World.Mask[entity] |= Has.ControlPlayer;
+            game.World.Get[entity] |= Has.ControlPlayer;
 
             // Selection box is the first child.
             let selection = transform.Children[0];
-            game.World.Mask[selection] |= Has.Draw;
+            game.World.Get[selection] |= Has.Draw;
         }
     } else {
         // When the cursor is not over the entity…
@@ -48,11 +48,11 @@ function update(game: Game, entity: Entity) {
         // …deselect it if the user clicks.
         if (selectable.Selected && game.InputDelta["Mouse0"] === -1) {
             selectable.Selected = false;
-            game.World.Mask[entity] &= ~Has.ControlPlayer;
+            game.World.Get[entity] &= ~Has.ControlPlayer;
 
             // Selection box is the first child.
             let selection = transform.Children[0];
-            game.World.Mask[selection] &= ~Has.Draw;
+            game.World.Get[selection] &= ~Has.Draw;
         }
     }
 }

--- a/PathFinding/systems/sys_transform.ts
+++ b/PathFinding/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/PathFinding/world.ts
+++ b/PathFinding/world.ts
@@ -41,7 +41,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Collide: Array<Collide> = [];

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ good practices, architecture decisions, and tools.
 Goodluck implements the entity-component-system (ECS) architecture:
 
 1.  _Entities_ are indices into arrays storing component data. A special
-    array called `Mask` stores masks defining which components are enabled
-    for which entities. Component masks are implemented using bitflags, which
-    limits the total number of available components to 32. This should still
-    be plenty for small and even medium-sized games.
+    array called `Get` stores bit fields defining which components are
+    enabled for which entities. Since bitwise operations are only defined for
+    32-bit integers in JavaScript, the total number of available components
+    is limited to 32. This should still be plenty for small and even
+    medium-sized games.
 
 2.  _Components_ are simple objects storing data, and only data. No logic
     goes into components. Each component defines an interface describing its

--- a/RenderTexture1/components/com_camera_display.ts
+++ b/RenderTexture1/components/com_camera_display.ts
@@ -15,7 +15,7 @@ export interface CameraDisplay {
 }
 export function camera_display(fovy: number, near: number, far: number, clear_color: Vec4) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             Kind: CameraKind.Display,
             FovY: fovy,

--- a/RenderTexture1/components/com_camera_framebuffer.ts
+++ b/RenderTexture1/components/com_camera_framebuffer.ts
@@ -53,7 +53,7 @@ export function camera_framebuffer(
             GL_RENDERBUFFER,
             depth_buffer
         );
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             Kind: CameraKind.Framebuffer,
             Target: target,

--- a/RenderTexture1/components/com_render_textured.ts
+++ b/RenderTexture1/components/com_render_textured.ts
@@ -55,7 +55,7 @@ export function render_textured(
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Textured,
             Material: material,

--- a/RenderTexture1/components/com_rotate.ts
+++ b/RenderTexture1/components/com_rotate.ts
@@ -9,7 +9,7 @@ export interface Rotate {
 
 export function rotate(rotation: Vec3) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Rotate;
+        game.World.Get[entity] |= Has.Rotate;
         game.World.Rotate[entity] = {
             Rotation: rotation,
         };

--- a/RenderTexture1/components/com_transform.ts
+++ b/RenderTexture1/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/RenderTexture1/core.ts
+++ b/RenderTexture1/core.ts
@@ -27,8 +27,8 @@ export function loop_stop(game: Game) {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -64,11 +64,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/RenderTexture1/systems/sys_camera.ts
+++ b/RenderTexture1/systems/sys_camera.ts
@@ -15,8 +15,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Cameras = [];
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let camera = game.World.Camera[i];
 
             if (camera.Kind === CameraKind.Display) {

--- a/RenderTexture1/systems/sys_render.ts
+++ b/RenderTexture1/systems/sys_render.ts
@@ -54,8 +54,8 @@ function render(game: Game, pv: Mat4, current_target?: WebGLTexture) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/RenderTexture1/systems/sys_rotate.ts
+++ b/RenderTexture1/systems/sys_rotate.ts
@@ -6,8 +6,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Rotate;
 
 export function sys_rotate(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/RenderTexture1/systems/sys_transform.ts
+++ b/RenderTexture1/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/RenderTexture1/world.ts
+++ b/RenderTexture1/world.ts
@@ -19,7 +19,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Render: Array<Render> = [];

--- a/RenderTexture2/components/com_camera_display.ts
+++ b/RenderTexture2/components/com_camera_display.ts
@@ -15,7 +15,7 @@ export interface CameraDisplay {
 }
 export function camera_display(fovy: number, near: number, far: number, clear_color: Vec4) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             Kind: CameraKind.Display,
             FovY: fovy,

--- a/RenderTexture2/components/com_camera_framebuffer.ts
+++ b/RenderTexture2/components/com_camera_framebuffer.ts
@@ -53,7 +53,7 @@ export function camera_framebuffer(
             depth_texture,
             0
         );
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             Kind: CameraKind.Framebuffer,
             Target: target,

--- a/RenderTexture2/components/com_render_textured.ts
+++ b/RenderTexture2/components/com_render_textured.ts
@@ -55,7 +55,7 @@ export function render_textured(
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Textured,
             Material: material,

--- a/RenderTexture2/components/com_rotate.ts
+++ b/RenderTexture2/components/com_rotate.ts
@@ -9,7 +9,7 @@ export interface Rotate {
 
 export function rotate(rotation: Vec3) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Rotate;
+        game.World.Get[entity] |= Has.Rotate;
         game.World.Rotate[entity] = {
             Rotation: rotation,
         };

--- a/RenderTexture2/components/com_transform.ts
+++ b/RenderTexture2/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/RenderTexture2/core.ts
+++ b/RenderTexture2/core.ts
@@ -27,8 +27,8 @@ export function loop_stop(game: Game) {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -64,11 +64,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/RenderTexture2/systems/sys_camera.ts
+++ b/RenderTexture2/systems/sys_camera.ts
@@ -15,8 +15,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Cameras = [];
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let camera = game.World.Camera[i];
 
             if (camera.Kind === CameraKind.Display) {

--- a/RenderTexture2/systems/sys_render.ts
+++ b/RenderTexture2/systems/sys_render.ts
@@ -54,8 +54,8 @@ function render(game: Game, pv: Mat4, current_target?: WebGLTexture) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/RenderTexture2/systems/sys_rotate.ts
+++ b/RenderTexture2/systems/sys_rotate.ts
@@ -6,8 +6,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Rotate;
 
 export function sys_rotate(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/RenderTexture2/systems/sys_transform.ts
+++ b/RenderTexture2/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/RenderTexture2/world.ts
+++ b/RenderTexture2/world.ts
@@ -19,7 +19,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Render: Array<Render> = [];

--- a/RigidBody/components/com_camera.ts
+++ b/RigidBody/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/RigidBody/components/com_collide.ts
+++ b/RigidBody/components/com_collide.ts
@@ -8,7 +8,7 @@ export interface Collide extends AABB {
     New: boolean;
     Dynamic: boolean;
     Layers: Layer;
-    Mask: Layer;
+    Get: Layer;
     Collisions: Array<Collision>;
 }
 
@@ -23,13 +23,13 @@ export interface Collide extends AABB {
  */
 export function collide(dynamic: boolean, layers: Layer, mask: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Collide;
+        game.World.Get[entity] |= Has.Collide;
         game.World.Collide[entity] = {
             Entity: entity,
             New: true,
             Dynamic: dynamic,
             Layers: layers,
-            Mask: mask,
+            Get: mask,
             Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],

--- a/RigidBody/components/com_control_spawner.ts
+++ b/RigidBody/components/com_control_spawner.ts
@@ -9,7 +9,7 @@ export interface ControlSpawner {
 
 export function control_spawner(Frequency: number, Spread: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.ControlSpawner;
+        game.World.Get[entity] |= Has.ControlSpawner;
         game.World.ControlSpawner[entity] = {
             Frequency,
             Spread,

--- a/RigidBody/components/com_lifespan.ts
+++ b/RigidBody/components/com_lifespan.ts
@@ -8,7 +8,7 @@ export interface Lifespan {
 
 export function lifespan(Max = Infinity) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Lifespan;
+        game.World.Get[entity] |= Has.Lifespan;
         game.World.Lifespan[entity] = {
             Max,
             Age: 0,

--- a/RigidBody/components/com_light.ts
+++ b/RigidBody/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/RigidBody/components/com_render_diffuse.ts
+++ b/RigidBody/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/RigidBody/components/com_rigid_body.ts
+++ b/RigidBody/components/com_rigid_body.ts
@@ -9,7 +9,7 @@ export interface RigidBody {
 
 export function rigid_body(Dynamic: boolean = true) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.RigidBody;
+        game.World.Get[entity] |= Has.RigidBody;
         game.World.RigidBody[entity] = {
             Dynamic,
             VelY: 0,

--- a/RigidBody/components/com_transform.ts
+++ b/RigidBody/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/RigidBody/core.ts
+++ b/RigidBody/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/RigidBody/systems/sys_camera.ts
+++ b/RigidBody/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/RigidBody/systems/sys_collide.ts
+++ b/RigidBody/systems/sys_collide.ts
@@ -10,8 +10,8 @@ export function sys_collide(game: Game, delta: number) {
     // Collect all colliders.
     let static_colliders: Collide[] = [];
     let dynamic_colliders: Collide[] = [];
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let collider = game.World.Collide[i];
 
@@ -51,8 +51,8 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        let collider_can_intersect = collider.Mask & other.Layers;
-        let other_can_intersect = other.Mask & collider.Layers;
+        let collider_can_intersect = collider.Get & other.Layers;
+        let other_can_intersect = other.Get & collider.Layers;
         if (collider_can_intersect || other_can_intersect) {
             if (intersect_aabb(collider, other)) {
                 let hit = penetrate_aabb(collider, other);

--- a/RigidBody/systems/sys_control_spawner.ts
+++ b/RigidBody/systems/sys_control_spawner.ts
@@ -9,8 +9,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.ControlSpawner;
 
 export function sys_control_spawner(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             update(game, i, delta);
         }
     }

--- a/RigidBody/systems/sys_lifespan.ts
+++ b/RigidBody/systems/sys_lifespan.ts
@@ -5,8 +5,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Lifespan;
 
 export function sys_lifespan(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) == QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) == QUERY) {
             update(game, i, delta);
         }
     }

--- a/RigidBody/systems/sys_light.ts
+++ b/RigidBody/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/RigidBody/systems/sys_physics.ts
+++ b/RigidBody/systems/sys_physics.ts
@@ -6,8 +6,8 @@ const QUERY = Has.Transform | Has.Collide | Has.RigidBody;
 const GRAVITY = -9.81;
 
 export function sys_physics(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }
@@ -27,7 +27,7 @@ function update(game: Game, entity: Entity, delta: number) {
 
         for (let i = 0; i < collide.Collisions.length; i++) {
             let collision = collide.Collisions[i];
-            if (game.World.Mask[collision.Other] & Has.RigidBody) {
+            if (game.World.Get[collision.Other] & Has.RigidBody) {
                 // Dynamic rigid bodies are only supported for top-level
                 // entities. Thus, no need to apply the world → self → local
                 // conversion to the collision response. Local space is world space.

--- a/RigidBody/systems/sys_render.ts
+++ b/RigidBody/systems/sys_render.ts
@@ -19,8 +19,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/RigidBody/systems/sys_transform.ts
+++ b/RigidBody/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/RigidBody/world.ts
+++ b/RigidBody/world.ts
@@ -31,7 +31,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Collide: Array<Collide> = [];

--- a/Shading/components/com_camera.ts
+++ b/Shading/components/com_camera.ts
@@ -14,7 +14,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/Shading/components/com_light.ts
+++ b/Shading/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/Shading/components/com_render_basic.ts
+++ b/Shading/components/com_render_basic.ts
@@ -41,7 +41,7 @@ export function render_basic(material: Material<BasicLayout>, mesh: Mesh, color:
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Basic,
             Material: material,

--- a/Shading/components/com_render_diffuse.ts
+++ b/Shading/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/Shading/components/com_render_specular.ts
+++ b/Shading/components/com_render_specular.ts
@@ -53,7 +53,7 @@ export function render_specular(
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Specular,
             Material: material,

--- a/Shading/components/com_rotate.ts
+++ b/Shading/components/com_rotate.ts
@@ -9,7 +9,7 @@ export interface Rotate {
 
 export function rotate(rotation: Vec3) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Rotate;
+        game.World.Get[entity] |= Has.Rotate;
         game.World.Rotate[entity] = {
             Rotation: rotation,
         };

--- a/Shading/components/com_transform.ts
+++ b/Shading/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/Shading/core.ts
+++ b/Shading/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/Shading/systems/sys_camera.ts
+++ b/Shading/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/Shading/systems/sys_light.ts
+++ b/Shading/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/Shading/systems/sys_render.ts
+++ b/Shading/systems/sys_render.ts
@@ -23,8 +23,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/Shading/systems/sys_rotate.ts
+++ b/Shading/systems/sys_rotate.ts
@@ -6,8 +6,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Rotate;
 
 export function sys_rotate(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/Shading/systems/sys_transform.ts
+++ b/Shading/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Shading/world.ts
+++ b/Shading/world.ts
@@ -22,7 +22,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Light: Array<Light> = [];

--- a/Texture/components/com_camera.ts
+++ b/Texture/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/Texture/components/com_render_textured.ts
+++ b/Texture/components/com_render_textured.ts
@@ -55,7 +55,7 @@ export function render_textured(
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Textured,
             Material: material,

--- a/Texture/components/com_rotate.ts
+++ b/Texture/components/com_rotate.ts
@@ -9,7 +9,7 @@ export interface Rotate {
 
 export function rotate(rotation: Vec3) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Rotate;
+        game.World.Get[entity] |= Has.Rotate;
         game.World.Rotate[entity] = {
             Rotation: rotation,
         };

--- a/Texture/components/com_transform.ts
+++ b/Texture/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/Texture/core.ts
+++ b/Texture/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/Texture/systems/sys_camera.ts
+++ b/Texture/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/Texture/systems/sys_render.ts
+++ b/Texture/systems/sys_render.ts
@@ -25,8 +25,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/Texture/systems/sys_rotate.ts
+++ b/Texture/systems/sys_rotate.ts
@@ -6,8 +6,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Rotate;
 
 export function sys_rotate(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/Texture/systems/sys_transform.ts
+++ b/Texture/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Texture/world.ts
+++ b/Texture/world.ts
@@ -19,7 +19,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Render: Array<Render> = [];

--- a/ThirdPerson/components/com_camera.ts
+++ b/ThirdPerson/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/ThirdPerson/components/com_collide.ts
+++ b/ThirdPerson/components/com_collide.ts
@@ -8,7 +8,7 @@ export interface Collide extends AABB {
     New: boolean;
     Dynamic: boolean;
     Layers: Layer;
-    Mask: Layer;
+    Get: Layer;
     Collisions: Array<Collision>;
 }
 
@@ -23,13 +23,13 @@ export interface Collide extends AABB {
  */
 export function collide(dynamic: boolean, layers: Layer, mask: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Collide;
+        game.World.Get[entity] |= Has.Collide;
         game.World.Collide[entity] = {
             Entity: entity,
             New: true,
             Dynamic: dynamic,
             Layers: layers,
-            Mask: mask,
+            Get: mask,
             Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],

--- a/ThirdPerson/components/com_control_player.ts
+++ b/ThirdPerson/components/com_control_player.ts
@@ -17,7 +17,7 @@ export interface ControlPlayer {
  */
 export function control_player(move: boolean, yaw: number, pitch: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.ControlPlayer;
+        game.World.Get[entity] |= Has.ControlPlayer;
         game.World.ControlPlayer[entity] = {
             Move: move,
             Yaw: yaw,

--- a/ThirdPerson/components/com_light.ts
+++ b/ThirdPerson/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/ThirdPerson/components/com_mimic.ts
+++ b/ThirdPerson/components/com_mimic.ts
@@ -10,7 +10,7 @@ export interface Mimic {
 
 export function mimic(Target: Entity, Stiffness: number = 0.1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Mimic;
+        game.World.Get[entity] |= Has.Mimic;
         game.World.Mimic[entity] = {
             Target,
             Stiffness,

--- a/ThirdPerson/components/com_move.ts
+++ b/ThirdPerson/components/com_move.ts
@@ -25,7 +25,7 @@ export interface Move {
  */
 export function move(MoveSpeed: number, RotateSpeed: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Move;
+        game.World.Get[entity] |= Has.Move;
         game.World.Move[entity] = {
             MoveSpeed,
             RotateSpeed,

--- a/ThirdPerson/components/com_named.ts
+++ b/ThirdPerson/components/com_named.ts
@@ -7,14 +7,14 @@ export interface Named {
 
 export function named(Name: string) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Named;
+        game.World.Get[entity] |= Has.Named;
         game.World.Named[entity] = {Name};
     };
 }
 
 export function find_first(world: World, name: string) {
-    for (let i = 0; i < world.Mask.length; i++) {
-        if (world.Mask[i] & Has.Named && world.Named[i].Name === name) {
+    for (let i = 0; i < world.Get.length; i++) {
+        if (world.Get[i] & Has.Named && world.Named[i].Name === name) {
             return i;
         }
     }

--- a/ThirdPerson/components/com_render_diffuse.ts
+++ b/ThirdPerson/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/ThirdPerson/components/com_rigid_body.ts
+++ b/ThirdPerson/components/com_rigid_body.ts
@@ -9,7 +9,7 @@ export interface RigidBody {
 
 export function rigid_body(Dynamic: boolean = true) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.RigidBody;
+        game.World.Get[entity] |= Has.RigidBody;
         game.World.RigidBody[entity] = {
             Dynamic,
             VelY: 0,

--- a/ThirdPerson/components/com_transform.ts
+++ b/ThirdPerson/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/ThirdPerson/core.ts
+++ b/ThirdPerson/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/ThirdPerson/systems/sys_camera.ts
+++ b/ThirdPerson/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/ThirdPerson/systems/sys_collide.ts
+++ b/ThirdPerson/systems/sys_collide.ts
@@ -10,8 +10,8 @@ export function sys_collide(game: Game, delta: number) {
     // Collect all colliders.
     let static_colliders: Collide[] = [];
     let dynamic_colliders: Collide[] = [];
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let collider = game.World.Collide[i];
 
@@ -51,8 +51,8 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        let collider_can_intersect = collider.Mask & other.Layers;
-        let other_can_intersect = other.Mask & collider.Layers;
+        let collider_can_intersect = collider.Get & other.Layers;
+        let other_can_intersect = other.Get & collider.Layers;
         if (collider_can_intersect || other_can_intersect) {
             if (intersect_aabb(collider, other)) {
                 let hit = penetrate_aabb(collider, other);

--- a/ThirdPerson/systems/sys_control_player.ts
+++ b/ThirdPerson/systems/sys_control_player.ts
@@ -8,8 +8,8 @@ const AXIS_X = <Vec3>[1, 0, 0];
 const AXIS_Y = <Vec3>[0, 1, 0];
 
 export function sys_control_player(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/ThirdPerson/systems/sys_light.ts
+++ b/ThirdPerson/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/ThirdPerson/systems/sys_mimic.ts
+++ b/ThirdPerson/systems/sys_mimic.ts
@@ -7,8 +7,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Mimic;
 
 export function sys_mimic(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let follower_transform = game.World.Transform[i];
             let follower_mimic = game.World.Mimic[i];
             let target_transform = game.World.Transform[follower_mimic.Target];

--- a/ThirdPerson/systems/sys_move.ts
+++ b/ThirdPerson/systems/sys_move.ts
@@ -14,8 +14,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Move;
 
 export function sys_move(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/ThirdPerson/systems/sys_physics.ts
+++ b/ThirdPerson/systems/sys_physics.ts
@@ -6,8 +6,8 @@ const QUERY = Has.Transform | Has.Collide | Has.RigidBody;
 const GRAVITY = -9.81;
 
 export function sys_physics(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }
@@ -27,7 +27,7 @@ function update(game: Game, entity: Entity, delta: number) {
 
         for (let i = 0; i < collide.Collisions.length; i++) {
             let collision = collide.Collisions[i];
-            if (game.World.Mask[collision.Other] & Has.RigidBody) {
+            if (game.World.Get[collision.Other] & Has.RigidBody) {
                 // Dynamic rigid bodies are only supported for top-level
                 // entities. Thus, no need to apply the world → self → local
                 // conversion to the collision response. Local space is world space.

--- a/ThirdPerson/systems/sys_render.ts
+++ b/ThirdPerson/systems/sys_render.ts
@@ -19,8 +19,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/ThirdPerson/systems/sys_transform.ts
+++ b/ThirdPerson/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/ThirdPerson/world.ts
+++ b/ThirdPerson/world.ts
@@ -37,7 +37,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Collide: Array<Collide> = [];

--- a/Trigger/components/com_camera.ts
+++ b/Trigger/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/Trigger/components/com_collide.ts
+++ b/Trigger/components/com_collide.ts
@@ -8,7 +8,7 @@ export interface Collide extends AABB {
     New: boolean;
     Dynamic: boolean;
     Layers: Layer;
-    Mask: Layer;
+    Get: Layer;
     Collisions: Array<Collision>;
 }
 
@@ -23,13 +23,13 @@ export interface Collide extends AABB {
  */
 export function collide(dynamic: boolean, layers: Layer, mask: Layer, size: Vec3 = [1, 1, 1]) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Collide;
+        game.World.Get[entity] |= Has.Collide;
         game.World.Collide[entity] = {
             Entity: entity,
             New: true,
             Dynamic: dynamic,
             Layers: layers,
-            Mask: mask,
+            Get: mask,
             Size: size,
             Min: [0, 0, 0],
             Max: [0, 0, 0],

--- a/Trigger/components/com_light.ts
+++ b/Trigger/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/Trigger/components/com_render_basic.ts
+++ b/Trigger/components/com_render_basic.ts
@@ -41,7 +41,7 @@ export function render_basic(material: Material<BasicLayout>, mesh: Mesh, color:
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Basic,
             Material: material,

--- a/Trigger/components/com_render_diffuse.ts
+++ b/Trigger/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/Trigger/components/com_rotate.ts
+++ b/Trigger/components/com_rotate.ts
@@ -9,7 +9,7 @@ export interface Rotate {
 
 export function rotate(rotation: Vec3) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Rotate;
+        game.World.Get[entity] |= Has.Rotate;
         game.World.Rotate[entity] = {
             Rotation: rotation,
         };

--- a/Trigger/components/com_transform.ts
+++ b/Trigger/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/Trigger/components/com_trigger.ts
+++ b/Trigger/components/com_trigger.ts
@@ -8,7 +8,7 @@ export interface Trigger {
 
 export function trigger(Action: Action) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Trigger;
+        game.World.Get[entity] |= Has.Trigger;
         game.World.Trigger[entity] = {
             Action,
         };

--- a/Trigger/core.ts
+++ b/Trigger/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/Trigger/systems/sys_camera.ts
+++ b/Trigger/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/Trigger/systems/sys_collide.ts
+++ b/Trigger/systems/sys_collide.ts
@@ -10,8 +10,8 @@ export function sys_collide(game: Game, delta: number) {
     // Collect all colliders.
     let static_colliders: Collide[] = [];
     let dynamic_colliders: Collide[] = [];
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let collider = game.World.Collide[i];
 
@@ -51,8 +51,8 @@ export function sys_collide(game: Game, delta: number) {
 function check_collisions(collider: Collide, colliders: Collide[], length: number) {
     for (let i = 0; i < length; i++) {
         let other = colliders[i];
-        let collider_can_intersect = collider.Mask & other.Layers;
-        let other_can_intersect = other.Mask & collider.Layers;
+        let collider_can_intersect = collider.Get & other.Layers;
+        let other_can_intersect = other.Get & collider.Layers;
         if (collider_can_intersect || other_can_intersect) {
             if (intersect_aabb(collider, other)) {
                 let hit = penetrate_aabb(collider, other);

--- a/Trigger/systems/sys_debug.ts
+++ b/Trigger/systems/sys_debug.ts
@@ -19,7 +19,7 @@ export function sys_debug(game: Game, delta: number) {
     for (let [key, wireframe] of wireframes) {
         if (
             // If the entity doesn't have TRANSFORM...
-            !(game.World.Mask[wireframe.anchor_entity] & Has.Transform) ||
+            !(game.World.Get[wireframe.anchor_entity] & Has.Transform) ||
             // ...or if it's not the same TRANSFORM.
             game.World.Transform[wireframe.anchor_entity] !== wireframe.anchor_transform
         ) {
@@ -28,17 +28,17 @@ export function sys_debug(game: Game, delta: number) {
         }
     }
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if (game.World.Mask[i] & Has.Transform) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if (game.World.Get[i] & Has.Transform) {
             // Draw colliders first. If the collider's wireframe overlaps
             // exactly with the transform's wireframe, we want the collider to
             // take priority.
-            if (game.World.Mask[i] & Has.Collide) {
+            if (game.World.Get[i] & Has.Collide) {
                 wireframe_collider(game, i);
             }
 
             // Draw invisible entities.
-            if (!(game.World.Mask[i] & Has.Render)) {
+            if (!(game.World.Get[i] & Has.Render)) {
                 wireframe_invisible(game, i);
             }
         }

--- a/Trigger/systems/sys_light.ts
+++ b/Trigger/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/Trigger/systems/sys_render.ts
+++ b/Trigger/systems/sys_render.ts
@@ -21,8 +21,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/Trigger/systems/sys_rotate.ts
+++ b/Trigger/systems/sys_rotate.ts
@@ -6,8 +6,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Rotate;
 
 export function sys_rotate(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, delta);
         }
     }

--- a/Trigger/systems/sys_transform.ts
+++ b/Trigger/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Trigger/systems/sys_trigger.ts
+++ b/Trigger/systems/sys_trigger.ts
@@ -5,8 +5,8 @@ import {Has} from "../world.js";
 const QUERY = Has.Transform | Has.Collide | Has.Trigger;
 
 export function sys_trigger(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/Trigger/world.ts
+++ b/Trigger/world.ts
@@ -28,7 +28,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Collide: Array<Collide> = [];

--- a/WebGL2/components/com_camera.ts
+++ b/WebGL2/components/com_camera.ts
@@ -13,7 +13,7 @@ export interface Camera {
 
 export function camera(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             FovY: fovy,
             Near: near,

--- a/WebGL2/components/com_light.ts
+++ b/WebGL2/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/WebGL2/components/com_render_diffuse.ts
+++ b/WebGL2/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/WebGL2/components/com_transform.ts
+++ b/WebGL2/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/WebGL2/core.ts
+++ b/WebGL2/core.ts
@@ -28,8 +28,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -65,11 +65,11 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }

--- a/WebGL2/systems/sys_camera.ts
+++ b/WebGL2/systems/sys_camera.ts
@@ -12,8 +12,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
 
             // Support only one camera per scene.

--- a/WebGL2/systems/sys_light.ts
+++ b/WebGL2/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/WebGL2/systems/sys_render.ts
+++ b/WebGL2/systems/sys_render.ts
@@ -19,8 +19,8 @@ export function sys_render(game: Game, delta: number) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/WebGL2/systems/sys_transform.ts
+++ b/WebGL2/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/WebGL2/world.ts
+++ b/WebGL2/world.ts
@@ -19,7 +19,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Light: Array<Light> = [];

--- a/WebVR/components/com_camera.ts
+++ b/WebVR/components/com_camera.ts
@@ -20,7 +20,7 @@ export interface CameraPerspective {
 
 export function camera_persp(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             Kind: CameraKind.Perspective,
             FovY: fovy,
@@ -40,7 +40,7 @@ export interface CameraVr {
 
 export function camera_vr() {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             Kind: CameraKind.Vr,
             PvLeft: create(),

--- a/WebVR/components/com_light.ts
+++ b/WebVR/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/WebVR/components/com_render_diffuse.ts
+++ b/WebVR/components/com_render_diffuse.ts
@@ -45,7 +45,7 @@ export function render_diffuse(material: Material<DiffuseLayout>, mesh: Mesh, co
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/WebVR/components/com_transform.ts
+++ b/WebVR/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/WebVR/core.ts
+++ b/WebVR/core.ts
@@ -30,8 +30,8 @@ export function loop_stop() {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -67,13 +67,13 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }
 
 export async function vr_init(game: Game) {

--- a/WebVR/systems/sys_camera.ts
+++ b/WebVR/systems/sys_camera.ts
@@ -18,8 +18,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let camera = game.World.Camera[i];
 
             if (camera.Kind === CameraKind.Vr && game.VrDisplay?.isPresenting) {

--- a/WebVR/systems/sys_light.ts
+++ b/WebVR/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/WebVR/systems/sys_render.ts
+++ b/WebVR/systems/sys_render.ts
@@ -46,8 +46,8 @@ function render(game: Game, pv: Mat4) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/WebVR/systems/sys_transform.ts
+++ b/WebVR/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }

--- a/WebVR/world.ts
+++ b/WebVR/world.ts
@@ -19,7 +19,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     Light: Array<Light> = [];

--- a/WebXR/components/com_camera.ts
+++ b/WebXR/components/com_camera.ts
@@ -20,7 +20,7 @@ export interface CameraPerspective {
 
 export function camera_persp(fovy: number, near: number, far: number) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             Kind: CameraKind.Perspective,
             FovY: fovy,
@@ -44,7 +44,7 @@ export interface CameraXr {
 
 export function camera_xr() {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Camera;
+        game.World.Get[entity] |= Has.Camera;
         game.World.Camera[entity] = {
             Kind: CameraKind.Xr,
             Eyes: [],

--- a/WebXR/components/com_control_xr.ts
+++ b/WebXR/components/com_control_xr.ts
@@ -9,7 +9,7 @@ export interface ControlXr {
 
 export function control_xr(hand: Hand) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.ControlXr;
+        game.World.Get[entity] |= Has.ControlXr;
         game.World.ControlXr[entity] = {
             Hand: hand,
         };

--- a/WebXR/components/com_light.ts
+++ b/WebXR/components/com_light.ts
@@ -18,7 +18,7 @@ export interface LightDirectional {
 
 export function light_directional(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Directional,
             Color: color,
@@ -35,7 +35,7 @@ export interface LightPoint {
 
 export function light_point(color: Vec3 = [1, 1, 1], range: number = 1) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Light;
+        game.World.Get[entity] |= Has.Light;
         game.World.Light[entity] = {
             Kind: LightKind.Point,
             Color: color,

--- a/WebXR/components/com_pose.ts
+++ b/WebXR/components/com_pose.ts
@@ -3,6 +3,6 @@ import {Has} from "../world.js";
 
 export function pose() {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Pose;
+        game.World.Get[entity] |= Has.Pose;
     };
 }

--- a/WebXR/components/com_render_diffuse.ts
+++ b/WebXR/components/com_render_diffuse.ts
@@ -50,7 +50,7 @@ export function render_diffuse(
             vaos.set(mesh, vao);
         }
 
-        game.World.Mask[entity] |= Has.Render;
+        game.World.Get[entity] |= Has.Render;
         game.World.Render[entity] = {
             Kind: RenderKind.Diffuse,
             Material: material,

--- a/WebXR/components/com_transform.ts
+++ b/WebXR/components/com_transform.ts
@@ -25,7 +25,7 @@ export function transform(
     Scale: Vec3 = [1, 1, 1]
 ) {
     return (game: Game, entity: Entity) => {
-        game.World.Mask[entity] |= Has.Transform;
+        game.World.Get[entity] |= Has.Transform;
         game.World.Transform[entity] = {
             World: create(),
             Self: create(),
@@ -47,7 +47,7 @@ export function transform(
  * @param mask Component mask to look for.
  */
 export function* query_all(world: World, parent: Entity, mask: Has): IterableIterator<Entity> {
-    if (world.Mask[parent] & mask) {
+    if (world.Get[parent] & mask) {
         yield parent;
     }
     for (let child of world.Transform[parent].Children) {

--- a/WebXR/core.ts
+++ b/WebXR/core.ts
@@ -43,8 +43,8 @@ export function loop_stop(game: Game) {
 
 export function create(world: World, mask: number = 0) {
     for (let i = 0; i < MAX_ENTITIES; i++) {
-        if (!world.Mask[i]) {
-            world.Mask[i] = mask;
+        if (!world.Get[i]) {
+            world.Get[i] = mask;
             return i;
         }
     }
@@ -80,13 +80,13 @@ export function instantiate(
 }
 
 export function destroy(world: World, entity: Entity) {
-    let mask = world.Mask[entity];
+    let mask = world.Get[entity];
     if (mask & Has.Transform) {
         for (let child of world.Transform[entity].Children) {
             destroy(world, child);
         }
     }
-    world.Mask[entity] = 0;
+    world.Get[entity] = 0;
 }
 
 export async function xr_init(game: Game) {

--- a/WebXR/systems/sys_camera.ts
+++ b/WebXR/systems/sys_camera.ts
@@ -13,8 +13,8 @@ export function sys_camera(game: Game, delta: number) {
     }
 
     game.Camera = undefined;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let camera = game.World.Camera[i];
 
             if (camera.Kind === CameraKind.Xr && game.XrFrame) {

--- a/WebXR/systems/sys_control_xr.ts
+++ b/WebXR/systems/sys_control_xr.ts
@@ -25,8 +25,8 @@ export function sys_control_xr(game: Game, delta: number) {
         }
     }
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, hand_left, hand_right);
         }
     }

--- a/WebXR/systems/sys_light.ts
+++ b/WebXR/systems/sys_light.ts
@@ -12,8 +12,8 @@ export function sys_light(game: Game, delta: number) {
     game.LightDetails.fill(0);
 
     let counter = 0;
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i, counter++);
         }
     }

--- a/WebXR/systems/sys_render.ts
+++ b/WebXR/systems/sys_render.ts
@@ -52,8 +52,8 @@ function render(game: Game, pv: Mat4) {
     let current_material = null;
     let current_front_face = null;
 
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             let transform = game.World.Transform[i];
             let render = game.World.Render[i];
 

--- a/WebXR/systems/sys_transform.ts
+++ b/WebXR/systems/sys_transform.ts
@@ -6,8 +6,8 @@ import {Has, World} from "../world.js";
 const QUERY = Has.Transform;
 
 export function sys_transform(game: Game, delta: number) {
-    for (let i = 0; i < game.World.Mask.length; i++) {
-        if ((game.World.Mask[i] & QUERY) === QUERY) {
+    for (let i = 0; i < game.World.Get.length; i++) {
+        if ((game.World.Get[i] & QUERY) === QUERY) {
             update(game, i);
         }
     }
@@ -19,7 +19,7 @@ function update(game: Game, entity: Entity) {
         transform.Dirty = false;
         set_children_as_dirty(game.World, transform);
 
-        if (game.World.Mask[entity] & Has.Pose) {
+        if (game.World.Get[entity] & Has.Pose) {
             // Pose transforms have their World matrix set from XRPose by other
             // systems. Their translation, rotation and scale are ignored.
         } else {

--- a/WebXR/world.ts
+++ b/WebXR/world.ts
@@ -24,7 +24,7 @@ export const enum Has {
 
 export class World {
     // Component flags
-    Mask: Array<number> = [];
+    Get: Array<number> = [];
     // Component data
     Camera: Array<Camera> = [];
     ControlXr: Array<ControlXr> = [];


### PR DESCRIPTION
`Mask` implies that these bit fields are supposed to, well, _mask_ (filter) some other bit fields. Instead, they define the composition of enabled components for an entity, and then systems can use masks to consider only a subset of all entities when they run.

I chose `Get` because of symmetry with the `Has` enum, e.g. `if (game.World.Get[entity] & Has.Pose) …`.