### PR TITLE
(FlyCamera) Add touch controls

### DIFF
--- a/FlyCamera/actions.ts
+++ b/FlyCamera/actions.ts
@@ -1,0 +1,19 @@
+import {Game} from "./game.js";
+
+export const enum Action {
+    ToggleFullscreen,
+    ExitFullscreen,
+}
+
+export function dispatch(game: Game, action: Action, args: unknown) {
+    switch (action) {
+        case Action.ToggleFullscreen: {
+            if (document.fullscreenElement) {
+                document.exitFullscreen();
+            } else {
+                document.body.requestFullscreen();
+            }
+            break;
+        }
+    }
+}

--- a/FlyCamera/game.ts
+++ b/FlyCamera/game.ts
@@ -14,6 +14,7 @@ import {sys_light} from "./systems/sys_light.js";
 import {sys_move} from "./systems/sys_move.js";
 import {sys_render} from "./systems/sys_render.js";
 import {sys_transform} from "./systems/sys_transform.js";
+import {sys_ui} from "./systems/sys_ui.js";
 import {World} from "./world.js";
 
 export type Entity = number;
@@ -138,6 +139,7 @@ export class Game {
         sys_light(this, delta);
         sys_render(this, delta);
         sys_draw(this, delta);
+        sys_ui(this, delta);
         sys_framerate(this, delta, performance.now() - now);
     }
 }

--- a/FlyCamera/game.ts
+++ b/FlyCamera/game.ts
@@ -6,6 +6,7 @@ import {loop_start, loop_stop} from "./core.js";
 import {sys_camera} from "./systems/sys_camera.js";
 import {sys_control_keyboard} from "./systems/sys_control_keyboard.js";
 import {sys_control_mouse} from "./systems/sys_control_mouse.js";
+import {sys_control_touch} from "./systems/sys_control_touch.js";
 import {sys_control_xbox} from "./systems/sys_control_xbox.js";
 import {sys_draw} from "./systems/sys_draw.js";
 import {sys_framerate} from "./systems/sys_framerate.js";
@@ -72,6 +73,42 @@ export class Game {
             this.InputDelta.MouseX = evt.movementX;
             this.InputDelta.MouseY = evt.movementY;
         });
+        this.Ui.addEventListener("touchstart", (evt) => {
+            for (let i = 0; i < evt.changedTouches.length; i++) {
+                let touch = evt.changedTouches[i];
+                this.InputState[`Touch${touch.identifier}`] = 1;
+                this.InputState[`Touch${touch.identifier}X`] = touch.screenX;
+                this.InputState[`Touch${touch.identifier}Y`] = touch.screenY;
+                this.InputDelta[`Touch${touch.identifier}`] = 1;
+                this.InputDelta[`Touch${touch.identifier}X`] = 0;
+                this.InputDelta[`Touch${touch.identifier}Y`] = 0;
+            }
+        });
+        this.Ui.addEventListener("touchmove", (evt) => {
+            for (let i = 0; i < evt.changedTouches.length; i++) {
+                let touch = evt.changedTouches[i];
+                this.InputDelta[`Touch${touch.identifier}X`] =
+                    touch.screenX - this.InputState[`Touch${touch.identifier}X`];
+                this.InputDelta[`Touch${touch.identifier}Y`] =
+                    touch.screenY - this.InputState[`Touch${touch.identifier}Y`];
+                this.InputState[`Touch${touch.identifier}X`] = touch.screenX;
+                this.InputState[`Touch${touch.identifier}Y`] = touch.screenY;
+            }
+        });
+        this.Ui.addEventListener("touchend", (evt) => {
+            for (let i = 0; i < evt.changedTouches.length; i++) {
+                let touch = evt.changedTouches[i];
+                this.InputState[`Touch${touch.identifier}`] = 0;
+                this.InputDelta[`Touch${touch.identifier}`] = -1;
+            }
+        });
+        this.Ui.addEventListener("touchcancel", (evt) => {
+            for (let i = 0; i < evt.changedTouches.length; i++) {
+                let touch = evt.changedTouches[i];
+                this.InputState[`Touch${touch.identifier}`] = 0;
+                this.InputDelta[`Touch${touch.identifier}`] = -1;
+            }
+        });
         this.Ui.addEventListener("wheel", (evt) => {
             this.InputDelta.WheelY = evt.deltaY;
         });
@@ -94,6 +131,7 @@ export class Game {
         sys_control_keyboard(this, delta);
         sys_control_mouse(this, delta);
         sys_control_xbox(this, delta);
+        sys_control_touch(this, delta);
         sys_move(this, delta);
         sys_transform(this, delta);
         sys_camera(this, delta);

--- a/FlyCamera/index.ts
+++ b/FlyCamera/index.ts
@@ -1,3 +1,4 @@
+import {dispatch} from "./actions.js";
 import {loop_start} from "./core.js";
 import {Game} from "./game.js";
 import {scene_stage} from "./scenes/sce_stage.js";
@@ -5,6 +6,9 @@ import {scene_stage} from "./scenes/sce_stage.js";
 let game = new Game();
 scene_stage(game);
 loop_start(game);
+
+// @ts-ignore
+window.$ = dispatch.bind(null, game);
 
 // @ts-ignore
 window.game = game;

--- a/FlyCamera/systems/sys_control_touch.ts
+++ b/FlyCamera/systems/sys_control_touch.ts
@@ -1,0 +1,67 @@
+import {DEG_TO_RAD, Quat, Vec2, Vec3} from "../../common/math.js";
+import {clamp} from "../../common/number.js";
+import {from_axis, multiply} from "../../common/quat.js";
+import {Entity, Game} from "../game.js";
+import {Has} from "../world.js";
+
+const QUERY = Has.Move | Has.ControlPlayer;
+const AXIS_Y: Vec3 = [0, 1, 0];
+const AXIS_X: Vec3 = [1, 0, 0];
+const DEAD_ZONE = 0.01;
+const TOUCH_SENSITIVITY = 10;
+
+// The position of the joystick center, given by the initial Touch0's x and y.
+let joystick: Vec2 = [0, 0];
+let rotation: Quat = [0, 0, 0, 0];
+
+export function sys_control_touch(game: Game, delta: number) {
+    if (game.InputDelta["Touch0"] === 1) {
+        // The center of the invisible joystick is given by the position of the
+        // first touch of the first finger on the screen's surface.
+        joystick[0] = game.InputState["Touch0X"];
+        joystick[1] = game.InputState["Touch0Y"];
+    }
+
+    for (let i = 0; i < game.World.Mask.length; i++) {
+        if ((game.World.Mask[i] & QUERY) === QUERY) {
+            update(game, i);
+        }
+    }
+}
+
+function update(game: Game, entity: Entity) {
+    let transform = game.World.Transform[entity];
+    let control = game.World.ControlPlayer[entity];
+    let move = game.World.Move[entity];
+
+    if (control.Move && game.InputState["Touch0"] === 1) {
+        let divider = Math.min(game.ViewportWidth, game.ViewportHeight);
+        let amount_x = (game.InputState["Touch0X"] - joystick[0]) / divider;
+        let amount_y = (game.InputState["Touch0Y"] - joystick[1]) / divider;
+
+        if (Math.abs(amount_x) > DEAD_ZONE) {
+            // Strafe movement.
+            move.Directions.push([clamp(-1, 1, -amount_x), 0, 0]);
+        }
+        if (Math.abs(amount_y) > DEAD_ZONE) {
+            // Forward movement.
+            move.Directions.push([0, 0, clamp(-1, 1, -amount_y)]);
+        }
+    }
+
+    if (control.Yaw && game.InputDelta["Touch1X"]) {
+        let amount = game.InputDelta["Touch1X"] * control.Yaw * TOUCH_SENSITIVITY;
+        // See sys_control_mouse.
+        from_axis(rotation, AXIS_Y, -amount * DEG_TO_RAD);
+        multiply(transform.Rotation, rotation, transform.Rotation);
+        transform.Dirty = true;
+    }
+
+    if (control.Pitch && game.InputDelta["Touch1Y"]) {
+        let amount = game.InputDelta["Touch1Y"] * control.Pitch * TOUCH_SENSITIVITY;
+        // See sys_control_mouse.
+        from_axis(rotation, AXIS_X, amount * DEG_TO_RAD);
+        multiply(transform.Rotation, transform.Rotation, rotation);
+        transform.Dirty = true;
+    }
+}

--- a/FlyCamera/systems/sys_ui.ts
+++ b/FlyCamera/systems/sys_ui.ts
@@ -1,0 +1,11 @@
+import {Game} from "../game.js";
+import {App} from "../ui/App.js";
+
+let prev: string;
+
+export function sys_ui(game: Game, delta: number) {
+    let next = App(game);
+    if (next !== prev) {
+        game.Ui.innerHTML = prev = next;
+    }
+}

--- a/FlyCamera/ui/App.ts
+++ b/FlyCamera/ui/App.ts
@@ -1,0 +1,11 @@
+import {html} from "../../common/html.js";
+import {Game} from "../game.js";
+import {Fullscreen} from "./Fullscreen.js";
+
+export function App(game: Game) {
+    return html`
+        <div>
+            ${Fullscreen()}
+        </div>
+    `;
+}

--- a/FlyCamera/ui/Fullscreen.ts
+++ b/FlyCamera/ui/Fullscreen.ts
@@ -1,0 +1,29 @@
+import {html} from "../../common/html.js";
+import {Action} from "../actions.js";
+
+export function Fullscreen() {
+    return html`
+        <div
+            style="
+                position: absolute;
+                top: 1vmin;
+                left: 1vmin;
+                background: #000;
+                color: #fff;
+                font: 13px Arial;
+            "
+        >
+            <button
+                onclick="$(${Action.ToggleFullscreen})"
+                style="
+                padding: 1vmin;
+                background: #000;
+                color: #fff;
+                border: none;
+            "
+            >
+                ${document.fullscreenElement ? "Exit Fullscreen" : "Enter Fullscreen"}
+            </button>
+        </div>
+    `;
+}


### PR DESCRIPTION
In #35 I separated `sys_control_player` into three systems, one for each input method: `sys_control_keyboard`, `sys_control_xbox` and `sys_control_mouse`. Following a [question on Twitter](https://twitter.com/naugtur/status/1281338461883162631), in this PR I've added a fourth method: `sys_control_touch`.

There's no special on-screen UI at this time, and the touch input works like this:
- The first finger that touches the screen is the _movement_ finger. The distance the finger moves from the initial point of contact is translated into `[-1, 1]` input, similar to the joystick controls.
- The second finger is then the freelook finger. The distance the finger moves every frame is translated to Euler degrees of rotation.

I also added `sys_ui` to the `FlyCamera` example to display the _Enter Fullscreen_ button. Without fullscreen some touches were interpreted by mobile browsers as scrolling, which hid or showed the address bar.