### PR TITLE
Inline source maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 *.js
-*.js.map
 play/index.html

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     ],
     "license": "ISC",
     "scripts": {
-        "clean": "find . -type d -name node_modules -prune -o \\( -name '*.js' -o -name '*.js.map' \\) -exec rm {} +",
+        "clean": "find . -type d -name node_modules -prune -o -name '*.js' -exec rm {} +",
         "compile": "tsc",
         "compile:watch": "tsc --watch -p .",
         "lint": "prettier --check \"**/*.ts\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "module": "es2020",
         "moduleResolution": "node",
         "strict": true,
-        "sourceMap": true
+        "inlineSourceMap": true
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
Rather than producing two files for each source `.ts` file (`.js` and `.js.map`), inline source maps at the end of the compiled `.js` file.

This PR also removes `.js.map` from `.gitignore`. To remove all previously compile source maps from your working copy, run the following command:

    find . -name "*.js.map" -exec rm {} +