### PR TITLE
Simple task implementation using the game loop

### DIFF
--- a/core/components/com_task.ts
+++ b/core/components/com_task.ts
@@ -1,0 +1,60 @@
+import {Entity, Game} from "../game.js";
+import {Has} from "../world.js";
+
+export type Task = TaskUntil | TaskTimeout;
+
+export const enum TaskKind {
+    Until,
+    Timeout,
+}
+
+type Predicate = () => boolean;
+type Callback = () => void;
+
+export interface TaskUntil {
+    Kind: TaskKind.Until;
+    Predicate: Predicate;
+    OnDone?: Callback;
+}
+
+/** A task that completes when the predicate returns true. */
+export function task_until(predicate: Predicate, on_done?: Callback) {
+    return (game: Game, entity: Entity) => {
+        game.World.Signature[entity] |= Has.Task;
+        game.World.Task[entity] = {
+            Kind: TaskKind.Until,
+            Predicate: predicate,
+            OnDone: on_done,
+        };
+    };
+}
+
+export interface TaskTimeout {
+    Kind: TaskKind.Timeout;
+    Remaining: number;
+    OnDone?: Callback;
+}
+
+/** A task that completes after the specified duration (in seconds). */
+export function task_timeout(duration: number, on_done?: Callback) {
+    return (game: Game, entity: Entity) => {
+        game.World.Signature[entity] |= Has.Task;
+        game.World.Task[entity] = {
+            Kind: TaskKind.Timeout,
+            Remaining: duration,
+            OnDone: on_done,
+        };
+    };
+}
+
+/** A task that completes as soon as possible. */
+export function task_complete(on_done: Callback) {
+    return (game: Game, entity: Entity) => {
+        game.World.Signature[entity] |= Has.Task;
+        game.World.Task[entity] = {
+            Kind: TaskKind.Timeout,
+            Remaining: 0,
+            OnDone: on_done,
+        };
+    };
+}

--- a/core/systems/sys_poll.ts
+++ b/core/systems/sys_poll.ts
@@ -1,0 +1,60 @@
+import {TaskKind} from "../components/com_task.js";
+import {Entity, Game} from "../game.js";
+import {Has, World} from "../world.js";
+
+const QUERY = Has.Task;
+
+export function sys_poll(game: Game, delta: number) {
+    // Collect all ready tasks first to avoid completing them while we stil
+    // literate over ohter tasks. This guarantees that tasks blocked by other
+    // tasks will be completed during the next frame.
+    let tasks_to_complete: Array<Entity> = [];
+
+    for (let i = 0; i < game.World.Signature.length; i++) {
+        if ((game.World.Signature[i] & QUERY) === QUERY) {
+            if (has_blocking_dependencies(game.World, i)) {
+                continue;
+            }
+
+            let task = game.World.Task[i];
+            switch (task.Kind) {
+                case TaskKind.Until: {
+                    if (task.Predicate()) {
+                        tasks_to_complete.push(i);
+                    }
+                    break;
+                }
+                case TaskKind.Timeout: {
+                    task.Remaining -= delta;
+                    if (task.Remaining < 0) {
+                        tasks_to_complete.push(i);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    for (let entity of tasks_to_complete) {
+        let task = game.World.Task[entity];
+
+        game.World.Signature[entity] &= ~Has.Task;
+        if (task.OnDone) {
+            task.OnDone();
+        }
+    }
+}
+
+function has_blocking_dependencies(world: World, entity: Entity) {
+    if (world.Signature[entity] & Has.Children) {
+        let children = world.Children[entity];
+        for (let child of children.Children) {
+            if (world.Signature[child] & Has.Task) {
+                // A pending child blocks the parent task.
+                return true;
+            }
+        }
+    }
+
+    return false;
+}

--- a/core/world.ts
+++ b/core/world.ts
@@ -12,6 +12,7 @@ import {Move} from "./components/com_move.js";
 import {Named} from "./components/com_named.js";
 import {RigidBody} from "./components/com_rigid_body.js";
 import {Shake} from "./components/com_shake.js";
+import {Task} from "./components/com_task.js";
 import {Transform} from "./components/com_transform.js";
 import {Transform2D} from "./components/com_transform2d.js";
 import {Trigger} from "./components/com_trigger.js";
@@ -34,6 +35,7 @@ const enum Component {
     Render,
     RigidBody,
     Shake,
+    Task,
     Transform,
     Transform2D,
     Trigger,
@@ -56,6 +58,7 @@ export const enum Has {
     Render = 1 << Component.Render,
     RigidBody = 1 << Component.RigidBody,
     Shake = 1 << Component.Shake,
+    Task = 1 << Component.Task,
     Transform = 1 << Component.Transform,
     Transform2D = 1 << Component.Transform2D,
     Trigger = 1 << Component.Trigger,
@@ -81,6 +84,7 @@ export interface World {
     // Render depends on the version of WebGL. See com_render*, sys_render*.
     RigidBody: Array<RigidBody>;
     Shake: Array<Shake>;
+    Task: Array<Task>;
     Transform: Array<Transform>;
     Transform2D: Array<Transform2D>;
     Trigger: Array<Trigger>;


### PR DESCRIPTION
Usage examples from [_Mirrorisk_](https://github.com/piesku/mirrorisk):

### [`sys_rules_phase`](https://github.com/piesku/mirrorisk/blob/master/src/systems/sys_rules_phase.ts)

Check if there are any pending tasks.

```ts
for (let i = 0; i < game.World.Signature.length; i++) {
    if (game.World.Signature[i] & Has.Task) {
        // Wait for the pending tasks to complete.
        return;
    }
}

// No more pending tasks here.

```

### [`sys_control_ai`](https://github.com/piesku/mirrorisk/blob/master/src/systems/sys_control_ai.ts)

Clear the `CurrentlyMovingAiUnit` semaphore (which allows the next AI unit to plan its movement) only when the current AI unit reaches its destination.

```ts
instantiate(game, [
    task_until(
        () => {
            let transform = game.World.Transform[entity];
            let world_position: Vec3 = [0, 0, 0];
            get_translation(world_position, transform.World);
            return distance_squared(world_position, dest) < CLOSE_ENOUGH_SQUARED;
        },
        () => {
            game.CurrentlyMovingAiUnit = null;
        }
    ),
]);
```

### [`sys_control_battle`](https://github.com/piesku/mirrorisk/blob/master/src/systems/sys_control_battle.ts)

Clear the `CurrentlyFoughtOverTerritory ` (which allows the next battle to be resolved) only when all killed units finish animating their deaths.

```ts
let defeated_unit_tasks: Array<Blueprint> = defeated_units.map((unit_entity) => [
    task_timeout(1, () => {
        destroy_entity(game.World, unit_entity);
    }),
]);

// Wait for all the defeated units to sink below the board.
instantiate(game, [
    children(...defeated_unit_tasks),
    task_complete(() => {
        game.CurrentlyFoughtOverTerritory = null;
    }),
]);
```