### PR TITLE
Introduce Camera2D, Projection2D

### DIFF
--- a/PathFinding/systems/sys_pick.ts
+++ b/PathFinding/systems/sys_pick.ts
@@ -38,7 +38,7 @@ function update(game: Game, entity: Entity, pickables: Array<Collide>) {
         throw new Error("XR not implemented");
     }
 
-    if (!pointer_viewport(pointer_position, game)) {
+    if (!pointer_viewport(game, pointer_position)) {
         // No mouse, no touch.
         return;
     }

--- a/Render2D/components/com_camera.ts
+++ b/Render2D/components/com_camera.ts
@@ -1,1 +1,0 @@
-../../core/components/com_camera.ts

--- a/Render2D/components/com_camera2d.ts
+++ b/Render2D/components/com_camera2d.ts
@@ -1,0 +1,1 @@
+../../core/components/com_camera2d.ts

--- a/Render2D/game.ts
+++ b/Render2D/game.ts
@@ -33,6 +33,7 @@ export class Game extends Game3D {
     constructor() {
         super();
 
+        this.Gl.clearColor(0, 0, 0, 0);
         this.Gl.enable(GL_BLEND);
         setup_render2d_buffers(this.Gl, this.InstanceBuffer);
     }

--- a/Render2D/materials/mat_instanced2d.ts
+++ b/Render2D/materials/mat_instanced2d.ts
@@ -8,7 +8,7 @@ let vertex = `#version 300 es\n
     uniform vec2 sheet_size;
 
     // Vertex attributes
-    layout(location=${Attribute.VertexPosition}) in vec3 attr_position;
+    layout(location=${Attribute.VertexPosition}) in vec2 attr_position;
     layout(location=${Attribute.VertexTexCoord}) in vec2 attr_texcoord;
 
     // Instance attributes
@@ -41,7 +41,7 @@ let vertex = `#version 300 es\n
                 );
             }
 
-            vec3 world_position = mat3(world) * attr_position;
+            vec3 world_position = mat3(world) * vec3(attr_position, 1);
             vec3 clip_position = mat3(pv) * world_position;
             gl_Position = vec4(clip_position.xy, attr_translation.z, 1);
 

--- a/Render2D/materials/mat_instanced2d.ts
+++ b/Render2D/materials/mat_instanced2d.ts
@@ -4,11 +4,11 @@ import {Attribute, Instanced2DLayout} from "../../materials/layout2d.js";
 import {Has} from "../world.js";
 
 let vertex = `#version 300 es\n
-    uniform mat4 pv;
+    uniform mat3x2 pv;
     uniform vec2 sheet_size;
 
     // Vertex attributes
-    layout(location=${Attribute.VertexPosition}) in vec4 attr_position;
+    layout(location=${Attribute.VertexPosition}) in vec3 attr_position;
     layout(location=${Attribute.VertexTexCoord}) in vec2 attr_texcoord;
 
     // Instance attributes
@@ -24,28 +24,26 @@ let vertex = `#version 300 es\n
     void main() {
         int signature = int(attr_translation.w);
         if ((signature & ${Has.Render2D}) == ${Has.Render2D}) {
-            mat4 world;
+            mat3x2 world;
             if ((signature & ${Has.SpatialNode2D}) == ${Has.SpatialNode2D}) {
-                world = mat4(
-                    attr_rotation.xy, 0, 0,
-                    attr_rotation.zw, 0, 0,
-                    0, 0, 1, 0,
-                    attr_translation.xyz, 1
+                world = mat3x2(
+                    attr_rotation.xy,
+                    attr_rotation.zw,
+                    attr_translation.xy
                 );
             } else {
-                vec3 translation = attr_translation.xyz;
                 vec2 scale = attr_rotation.xy;
                 float rotation = attr_rotation.z;
-                world = mat4(
-                    cos(rotation) * scale.x, sin(rotation) * scale.x, 0, 0,
-                    -sin(rotation) * scale.y, cos(rotation) * scale.y, 0, 0,
-                    0, 0, 1, 0,
-                    translation, 1
+                world = mat3x2(
+                    cos(rotation) * scale.x, sin(rotation) * scale.x,
+                    -sin(rotation) * scale.y, cos(rotation) * scale.y,
+                    attr_translation.xy
                 );
             }
 
-            vec4 world_position = world * attr_position;
-            gl_Position = pv * world_position;
+            vec3 world_position = mat3(world) * attr_position;
+            vec3 clip_position = mat3(pv) * world_position;
+            gl_Position = vec4(clip_position.xy, attr_translation.z, 1);
 
             // attr_texcoords are +Y=down for compatibility with spritesheet frame coordinates.
             vert_texcoord = (attr_sprite.xy + attr_sprite.zw * attr_texcoord) / sheet_size;

--- a/Render2D/materials/mat_instanced2d.ts
+++ b/Render2D/materials/mat_instanced2d.ts
@@ -43,7 +43,7 @@ let vertex = `#version 300 es\n
 
             vec3 world_position = mat3(world) * vec3(attr_position, 1);
             vec3 clip_position = mat3(pv) * world_position;
-            gl_Position = vec4(clip_position.xy, attr_translation.z, 1);
+            gl_Position = vec4(clip_position.xy, -attr_translation.z, 1);
 
             // attr_texcoords are +Y=down for compatibility with spritesheet frame coordinates.
             vert_texcoord = (attr_sprite.xy + attr_sprite.zw * attr_texcoord) / sheet_size;

--- a/Render2D/scenes/sce_stage.ts
+++ b/Render2D/scenes/sce_stage.ts
@@ -70,6 +70,7 @@ export function scene_stage(game: Game) {
                 element(["potato_raw.png", "carrot_raw.png"]),
                 hsva_to_vec4(float(0.1, 0.2), 0.5, 1, 1)
             ),
+            order(0.1),
             rigid_body2d(RigidKind.Dynamic, float(0.01, 0.02)),
         ]);
     }

--- a/Render2D/scenes/sce_stage.ts
+++ b/Render2D/scenes/sce_stage.ts
@@ -1,9 +1,8 @@
 import {hsva_to_vec4} from "../../common/color.js";
 import {instantiate} from "../../common/game.js";
-import {orthographic} from "../../common/projection.js";
 import {element, float} from "../../common/random.js";
 import {animate_sprite} from "../components/com_animate_sprite.js";
-import {camera_canvas} from "../components/com_camera.js";
+import {camera2d} from "../components/com_camera2d.js";
 import {children} from "../components/com_children.js";
 import {control_always2d} from "../components/com_control_always2d.js";
 import {control_player} from "../components/com_control_player.js";
@@ -23,10 +22,7 @@ export function scene_stage(game: Game) {
     instantiate(game, [
         spatial_node2d(),
         local_transform2d([0, 0]),
-        camera_canvas(
-            orthographic([game.SceneWidth / 2 + 1, game.SceneHeight / 2 + 1], 1, 3),
-            [0, 0, 0, 0]
-        ),
+        camera2d([game.SceneWidth / 2 + 1, game.SceneHeight / 2 + 1]),
     ]);
 
     {

--- a/Render2D/systems/sys_control_player.ts
+++ b/Render2D/systems/sys_control_player.ts
@@ -22,7 +22,7 @@ export function sys_control_player(game: Game, delta: number) {
 
     let camera = game.World.Camera2D[camera_entity];
 
-    if (pointer_viewport(pointer_position, game) && pointer_down(game, 0)) {
+    if (pointer_viewport(game, pointer_position) && pointer_down(game, 0)) {
         viewport_to_world(pointer_position, camera, pointer_position);
 
         for (let i = 0; i < game.World.Signature.length; i++) {

--- a/Render2D/systems/sys_control_player.ts
+++ b/Render2D/systems/sys_control_player.ts
@@ -2,18 +2,17 @@
  * @module systems/sys_control_player
  */
 
-import {pointer_down, pointer_ndc_far} from "../../common/input.js";
-import {transform_point} from "../../common/mat2d.js";
-import {Vec2, Vec3} from "../../common/math.js";
+import {pointer_down, pointer_viewport} from "../../common/input.js";
+import {Vec2} from "../../common/math.js";
 import {distance_squared, scale} from "../../common/vec2.js";
 import {Entity} from "../../common/world.js";
+import {viewport_to_world} from "../components/com_camera2d.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
 
 const QUERY = Has.ControlPlayer | Has.RigidBody2D;
 
-let pointer_3d_position: Vec3 = [0, 0, 0];
-let pointer_2d_position: Vec2 = [0, 0];
+let pointer_position: Vec2 = [0, 0];
 
 export function sys_control_player(game: Game, delta: number) {
     let camera_entity = game.Cameras[0];
@@ -23,20 +22,12 @@ export function sys_control_player(game: Game, delta: number) {
 
     let camera = game.World.Camera2D[camera_entity];
 
-    if (pointer_ndc_far(pointer_3d_position, game) && pointer_down(game, 0)) {
-        pointer_2d_position[0] = pointer_3d_position[0];
-        pointer_2d_position[1] = pointer_3d_position[1];
-
-        // The pointer position is in NDC space. Transform it to the eye space...
-        transform_point(pointer_2d_position, pointer_2d_position, camera.Projection.Inverse);
-
-        // ...and then to the world space.
-        let camera_node = game.World.SpatialNode2D[camera_entity];
-        transform_point(pointer_2d_position, pointer_2d_position, camera_node.World);
+    if (pointer_viewport(pointer_position, game) && pointer_down(game, 0)) {
+        viewport_to_world(pointer_position, camera, pointer_position);
 
         for (let i = 0; i < game.World.Signature.length; i++) {
             if ((game.World.Signature[i] & QUERY) === QUERY) {
-                update(game, i, pointer_2d_position);
+                update(game, i, pointer_position);
             }
         }
     }

--- a/Render2D/systems/sys_control_player.ts
+++ b/Render2D/systems/sys_control_player.ts
@@ -6,9 +6,7 @@ import {pointer_down, pointer_ndc_far} from "../../common/input.js";
 import {transform_point} from "../../common/mat2d.js";
 import {Vec2, Vec3} from "../../common/math.js";
 import {distance_squared, scale} from "../../common/vec2.js";
-import {transform_position} from "../../common/vec3.js";
 import {Entity} from "../../common/world.js";
-import {CameraKind} from "../components/com_camera.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
 
@@ -23,19 +21,17 @@ export function sys_control_player(game: Game, delta: number) {
         return;
     }
 
-    let camera = game.World.Camera[camera_entity];
-    if (camera.Kind === CameraKind.Xr) {
-        throw new Error("XR not implemented");
-    }
+    let camera = game.World.Camera2D[camera_entity];
 
     if (pointer_ndc_far(pointer_3d_position, game) && pointer_down(game, 0)) {
+        pointer_2d_position[0] = pointer_3d_position[0];
+        pointer_2d_position[1] = pointer_3d_position[1];
+
         // The pointer position is in NDC space. Transform it to the eye space...
-        transform_position(pointer_3d_position, pointer_3d_position, camera.Projection.Inverse);
+        transform_point(pointer_2d_position, pointer_2d_position, camera.Projection.Inverse);
 
         // ...and then to the world space.
         let camera_node = game.World.SpatialNode2D[camera_entity];
-        pointer_2d_position[0] = pointer_3d_position[0];
-        pointer_2d_position[1] = pointer_3d_position[1];
         transform_point(pointer_2d_position, pointer_2d_position, camera_node.World);
 
         for (let i = 0; i < game.World.Signature.length; i++) {

--- a/Render2D/world.ts
+++ b/Render2D/world.ts
@@ -1,6 +1,6 @@
 import {WorldImpl} from "../common/world.js";
+import {Camera2D} from "../core/components/com_camera2d.js";
 import {AnimateSprite} from "./components/com_animate_sprite.js";
-import {Camera} from "./components/com_camera.js";
 import {Children} from "./components/com_children.js";
 import {ControlAlways2D} from "./components/com_control_always2d.js";
 import {ControlPlayer} from "./components/com_control_player.js";
@@ -12,7 +12,7 @@ import {LocalTransform2D, SpatialNode2D} from "./components/com_transform2d.js";
 
 const enum Component {
     AnimateSprite,
-    Camera,
+    Camera2D,
     ControlAlways2D,
     ControlPlayer,
     Children,
@@ -28,7 +28,7 @@ const enum Component {
 export const enum Has {
     None = 0,
     AnimateSprite = 1 << Component.AnimateSprite,
-    Camera = 1 << Component.Camera,
+    Camera2D = 1 << Component.Camera2D,
     ControlAlways2D = 1 << Component.ControlAlways2D,
     ControlPlayer = 1 << Component.ControlPlayer,
     Children = 1 << Component.Children,
@@ -43,7 +43,7 @@ export const enum Has {
 
 export class World extends WorldImpl {
     AnimateSprite: Array<AnimateSprite> = [];
-    Camera: Array<Camera> = [];
+    Camera2D: Array<Camera2D> = [];
     ControlAlways2D: Array<ControlAlways2D> = [];
     ControlPlayer: Array<ControlPlayer> = [];
     Children: Array<Children> = [];

--- a/Render2D/world.ts
+++ b/Render2D/world.ts
@@ -1,6 +1,6 @@
 import {WorldImpl} from "../common/world.js";
-import {Camera2D} from "../core/components/com_camera2d.js";
 import {AnimateSprite} from "./components/com_animate_sprite.js";
+import {Camera2D} from "./components/com_camera2d.js";
 import {Children} from "./components/com_children.js";
 import {ControlAlways2D} from "./components/com_control_always2d.js";
 import {ControlPlayer} from "./components/com_control_player.js";

--- a/common/input.ts
+++ b/common/input.ts
@@ -17,7 +17,7 @@ export function pointer_clicked(game: GameImpl, mouse_button: number, touch_id =
     );
 }
 
-export function pointer_viewport(out: Vec2, game: GameImpl): boolean {
+export function pointer_viewport(game: GameImpl, out: Vec2): boolean {
     if (game.InputState["Touch0"] === 1 || game.InputDelta["Touch0"] === -1) {
         out[0] = game.InputState["Touch0X"];
         out[1] = game.InputState["Touch0Y"];

--- a/common/input.ts
+++ b/common/input.ts
@@ -1,5 +1,5 @@
 import {GameImpl} from "./game";
-import {Vec2, Vec3} from "./math";
+import {Vec2} from "./math";
 
 export function input_pointer_lock(game: GameImpl) {
     game.Ui.addEventListener("click", () => game.Ui.requestPointerLock());
@@ -17,7 +17,7 @@ export function pointer_clicked(game: GameImpl, mouse_button: number, touch_id =
     );
 }
 
-export function pointer_viewport(out: Vec2 | Vec3, game: GameImpl): boolean {
+export function pointer_viewport(out: Vec2, game: GameImpl): boolean {
     if (game.InputState["Touch0"] === 1 || game.InputDelta["Touch0"] === -1) {
         out[0] = game.InputState["Touch0X"];
         out[1] = game.InputState["Touch0Y"];
@@ -27,20 +27,6 @@ export function pointer_viewport(out: Vec2 | Vec3, game: GameImpl): boolean {
     if (game.InputDistance["Mouse"] > 0) {
         out[0] = game.InputState["MouseX"];
         out[1] = game.InputState["MouseY"];
-        return true;
-    }
-
-    // No mouse, no touch.
-    return false;
-}
-
-export function pointer_ndc_far(out: Vec3, game: GameImpl): boolean {
-    if (pointer_viewport(out, game)) {
-        out[0] = (out[0] / game.ViewportWidth) * 2 - 1;
-        // In the browser, +Y is down. Invert it, so that in NDC it's up.
-        out[1] = -(out[1] / game.ViewportHeight) * 2 + 1;
-        // Assume the pointer is on the far plane.
-        out[2] = 1;
         return true;
     }
 

--- a/common/mat2d.ts
+++ b/common/mat2d.ts
@@ -182,14 +182,6 @@ export function get_translation(out: Vec2, a: Mat2D) {
     return out;
 }
 
-export function transform_point(out: Vec2, a: Vec2, m: Mat2D) {
-    let x = a[0];
-    let y = a[1];
-    out[0] = m[0] * x + m[2] * y + m[4];
-    out[1] = m[1] * x + m[3] * y + m[5];
-    return out;
-}
-
 export function from_ortho(out: Mat2D, left: number, top: number) {
     set(out, left, 0, 0, top, 0, 0);
     return out;

--- a/common/mat2d.ts
+++ b/common/mat2d.ts
@@ -184,3 +184,8 @@ export function transform_point(out: Vec2, a: Vec2, m: Mat2D) {
     out[1] = m[1] * x + m[3] * y + m[5];
     return out;
 }
+
+export function from_ortho(out: Mat2D, left: number, top: number) {
+    set(out, left, 0, 0, top, 0, 0);
+    return out;
+}

--- a/common/mat2d.ts
+++ b/common/mat2d.ts
@@ -22,6 +22,11 @@ export function set(
     return out;
 }
 
+export function copy(out: Mat2D, a: Mat2D) {
+    set(out, a[0], a[1], a[2], a[3], a[4], a[5]);
+    return out;
+}
+
 export function invert(out: Mat2D, a: Mat2D) {
     let aa = a[0],
         ab = a[1],

--- a/common/projection.ts
+++ b/common/projection.ts
@@ -47,9 +47,6 @@ export interface ProjectionOrthographic {
 /**
  * Create an orthographic projection.
  *
- * As a special case, if the radius is [0, 0], sys_resize2d will dynamically
- * resize the projection to keep the unit size in pixels constant.
- *
  * @param radius The radius of the projection: [left, top].
  * @param near The near clipping plane.
  * @param far The far clipping plane.

--- a/common/projection.ts
+++ b/common/projection.ts
@@ -82,7 +82,7 @@ export interface ProjectionOrthographic {
  * As a special case, if the radius is [0, 0], sys_resize2d will dynamically
  * resize the projection to keep the unit size in pixels constant.
  *
- * @param radius The radius of the projection: [top, left].
+ * @param radius The radius of the projection: [left, top].
  * @param near The near clipping plane.
  * @param far The far clipping plane.
  */

--- a/common/projection.ts
+++ b/common/projection.ts
@@ -1,4 +1,4 @@
-import {create, from_ortho, from_perspective, invert} from "./mat4.js";
+import {create} from "./mat4.js";
 import {Mat4, Vec2} from "./math.js";
 
 export type Projection = ProjectionPerspective | ProjectionOrthographic;
@@ -35,38 +35,6 @@ export function perspective(fov_y: number, near: number, far: number): Projectio
     };
 }
 
-/**
- * Resize a perspective projection.
- *
- *     let aspect = viewport_width / viewport_height;
- *     resize_perspective(camera.Projection, aspect);
- *
- * @param projection The projection to resize.
- * @param aspect The aspect ratio of the viewport.
- */
-export function resize_perspective(projection: ProjectionPerspective, aspect: number) {
-    if (aspect < 1) {
-        // Portrait orientation.
-        from_perspective(
-            projection.Projection,
-            projection.FovY / aspect,
-            aspect,
-            projection.Near,
-            projection.Far
-        );
-    } else {
-        // Landscape orientation.
-        from_perspective(
-            projection.Projection,
-            projection.FovY,
-            aspect,
-            projection.Near,
-            projection.Far
-        );
-    }
-    invert(projection.Inverse, projection.Projection);
-}
-
 export interface ProjectionOrthographic {
     Kind: ProjectionKind.Orthographic;
     Radius: Vec2;
@@ -95,74 +63,4 @@ export function orthographic(radius: Vec2, near: number, far: number): Projectio
         Projection: create(),
         Inverse: create(),
     };
-}
-
-/**
- * Resize an orthographic projection.
- *
- *     let aspect = viewport_width / viewport_height;
- *     resize_ortho(camera.Projection, aspect);
- *
- * @param projection The projection to resize.
- * @param aspect The aspect ratio of the viewport.
- */
-export function resize_ortho(projection: ProjectionOrthographic, aspect: number) {
-    let target_aspect = projection.Radius[0] / projection.Radius[1];
-    if (aspect < target_aspect) {
-        // Portrait orientation.
-        from_ortho(
-            projection.Projection,
-            projection.Radius[0] / aspect,
-            projection.Radius[0],
-            -projection.Radius[0] / aspect,
-            -projection.Radius[0],
-            projection.Near,
-            projection.Far
-        );
-    } else {
-        // Landscape orientation.
-        from_ortho(
-            projection.Projection,
-            projection.Radius[1],
-            projection.Radius[1] * aspect,
-            -projection.Radius[1],
-            -projection.Radius[1] * aspect,
-            projection.Near,
-            projection.Far
-        );
-    }
-    invert(projection.Inverse, projection.Projection);
-}
-
-/**
- * Resize an orthographic projection using a user-defined radius.
- *
- * Ignore projection.Radius and instead apply a user-defined radius which can be
- * dynamically computed taking into account the world unit size in pixels. This
- * is useful for keeping the unit size constant across different viewport
- * dimensions, and help pixel art sprites look crisp.
- *
- *     let radius = viewport_height / unit_size_px / 2;
- *     let aspect = viewport_width / viewport_height;
- *     resize_ortho_constant(camera.Projection, radius, aspect);
- *
- * @param projection The projection to resize.
- * @param radius_y The Y radius (= top = bottom) to override projection.Radius.
- * @param aspect The aspect ratio of the viewport.
- */
-export function resize_ortho_constant(
-    projection: ProjectionOrthographic,
-    radius_y: number,
-    aspect: number
-) {
-    from_ortho(
-        projection.Projection,
-        radius_y,
-        radius_y * aspect,
-        -radius_y,
-        -radius_y * aspect,
-        projection.Near,
-        projection.Far
-    );
-    invert(projection.Inverse, projection.Projection);
 }

--- a/common/projection2d.ts
+++ b/common/projection2d.ts
@@ -1,0 +1,29 @@
+import {create, set} from "./mat2d.js";
+import {Mat2D, Vec2} from "./math.js";
+
+export interface Projection2D {
+    Radius: Vec2;
+    Projection: Mat2D;
+    Inverse: Mat2D;
+}
+
+/**
+ * Create an orthographic projection.
+ *
+ * As a special case, if the radius is [0, 0], sys_resize2d will dynamically
+ * resize the projection to keep the unit size in pixels constant.
+ *
+ * @param radius The radius of the projection: [left, top].
+ */
+export function orthographic2d(radius: Vec2): Projection2D {
+    return {
+        Radius: radius,
+        Projection: from_ortho(create(), radius[0], radius[1]),
+        Inverse: create(),
+    };
+}
+
+export function from_ortho(mat: Mat2D, left: number, top: number) {
+    set(mat, left, 0, 0, top, 0, 0);
+    return mat;
+}

--- a/common/projection2d.ts
+++ b/common/projection2d.ts
@@ -1,4 +1,4 @@
-import {create, set} from "./mat2d.js";
+import {create, from_ortho} from "./mat2d.js";
 import {Mat2D, Vec2} from "./math.js";
 
 export interface Projection2D {
@@ -21,9 +21,4 @@ export function orthographic2d(radius: Vec2): Projection2D {
         Projection: from_ortho(create(), radius[0], radius[1]),
         Inverse: create(),
     };
-}
-
-export function from_ortho(mat: Mat2D, left: number, top: number) {
-    set(mat, left, 0, 0, top, 0, 0);
-    return mat;
 }

--- a/core/components/com_camera.ts
+++ b/core/components/com_camera.ts
@@ -21,7 +21,6 @@ export const enum CameraKind {
 
 // The subset of camera data passed into render methods.
 export interface CameraEye {
-    View: Mat4;
     Pv: Mat4;
     Position: Vec3;
     FogColor: Vec4;
@@ -49,7 +48,6 @@ export function camera_canvas(
             Projection: projection,
             ViewportWidth: 0,
             ViewportHeight: 0,
-            View: create(),
             Pv: create(),
             Position: [0, 0, 0],
             FogColor: clear_color,
@@ -80,7 +78,6 @@ export function camera_target(
             Kind: CameraKind.Target,
             Target: target,
             Projection: projection,
-            View: create(),
             Pv: create(),
             Position: [0, 0, 0],
             FogColor: clear_color,

--- a/core/components/com_camera.ts
+++ b/core/components/com_camera.ts
@@ -31,6 +31,8 @@ export interface CameraEye {
 export interface CameraCanvas extends CameraEye {
     Kind: CameraKind.Canvas;
     Projection: Projection;
+    ViewportWidth: number;
+    ViewportHeight: number;
     ClearColor: Vec4;
     ClearMask: number;
 }
@@ -45,6 +47,8 @@ export function camera_canvas(
         game.World.Camera[entity] = {
             Kind: CameraKind.Canvas,
             Projection: projection,
+            ViewportWidth: 0,
+            ViewportHeight: 0,
             View: create(),
             Pv: create(),
             Position: [0, 0, 0],

--- a/core/components/com_camera.ts
+++ b/core/components/com_camera.ts
@@ -4,8 +4,9 @@
 
 import {RenderTarget} from "../../common/framebuffer.js";
 import {create} from "../../common/mat4.js";
-import {Mat4, Vec3, Vec4} from "../../common/math.js";
+import {Mat4, Vec2, Vec3, Vec4} from "../../common/math.js";
 import {Projection} from "../../common/projection.js";
+import {transform_position} from "../../common/vec3.js";
 import {GL_COLOR_BUFFER_BIT, GL_DEPTH_BUFFER_BIT} from "../../common/webgl.js";
 import {Entity} from "../../common/world.js";
 import {Game} from "../game.js";
@@ -30,6 +31,7 @@ export interface CameraEye {
 export interface CameraCanvas extends CameraEye {
     Kind: CameraKind.Canvas;
     Projection: Projection;
+    World: Mat4;
     ViewportWidth: number;
     ViewportHeight: number;
     ClearColor: Vec4;
@@ -46,6 +48,7 @@ export function camera_canvas(
         game.World.Camera[entity] = {
             Kind: CameraKind.Canvas,
             Projection: projection,
+            World: create(),
             ViewportWidth: 0,
             ViewportHeight: 0,
             Pv: create(),
@@ -62,6 +65,9 @@ export interface CameraTarget extends CameraEye {
     Kind: CameraKind.Target;
     Target: RenderTarget;
     Projection: Projection;
+    World: Mat4;
+    ViewportWidth: number;
+    ViewportHeight: number;
     ClearColor: Vec4;
     ClearMask: number;
 }
@@ -78,6 +84,9 @@ export function camera_target(
             Kind: CameraKind.Target,
             Target: target,
             Projection: projection,
+            World: create(),
+            ViewportWidth: 0,
+            ViewportHeight: 0,
             Pv: create(),
             Position: [0, 0, 0],
             FogColor: clear_color,
@@ -95,6 +104,7 @@ export interface XrEye extends CameraEye {
 export interface CameraXr {
     Kind: CameraKind.Xr;
     Eyes: Array<XrEye>;
+    World: Mat4;
     ClearColor: Vec4;
     ClearMask: number;
 }
@@ -108,8 +118,25 @@ export function camera_xr(
         game.World.Camera[entity] = {
             Kind: CameraKind.Xr,
             Eyes: [],
+            World: create(),
             ClearColor: clear_color,
             ClearMask: clear_mask,
         };
     };
+}
+
+// Utilities.
+
+export function viewport_to_world(out: Vec3, camera: CameraCanvas | CameraTarget, pos: Vec2) {
+    // Transform the position from viewport space to the NDC space (where +Y is up).
+    out[0] = (pos[0] / camera.ViewportWidth) * 2 - 1;
+    out[1] = -(pos[1] / camera.ViewportHeight) * 2 + 1;
+    // Assume pos is on the far plane.
+    out[2] = 1;
+
+    // ...then to the eye space...
+    transform_position(out, out, camera.Projection.Inverse);
+
+    // ...and then to the world space.
+    transform_position(out, out, camera.World);
 }

--- a/core/components/com_camera2d.ts
+++ b/core/components/com_camera2d.ts
@@ -13,7 +13,8 @@ export interface Camera2D {
     Projection: Projection2D;
     Pv: Mat2D;
     World: Mat2D;
-    ViewportSize: Vec2;
+    ViewportWidth: number;
+    ViewportHeight: number;
 }
 
 export function camera2d(radius: Vec2) {
@@ -27,17 +28,18 @@ export function camera2d(radius: Vec2) {
             },
             Pv: create(),
             World: create(),
-            ViewportSize: [0, 0],
+            ViewportWidth: 0,
+            ViewportHeight: 0,
         };
     };
 }
 
 export function viewport_to_world(out: Vec2, camera: Camera2D, pos: Vec2) {
-    // Transform the position from viewport space to NDC space (where +Y is up).
-    out[0] = (pos[0] / camera.ViewportSize[0]) * 2 - 1;
-    out[1] = -(pos[1] / camera.ViewportSize[1]) * 2 + 1;
+    // Transform the position from viewport space to the NDC space (where +Y is up).
+    out[0] = (pos[0] / camera.ViewportWidth) * 2 - 1;
+    out[1] = -(pos[1] / camera.ViewportHeight) * 2 + 1;
 
-    // ...then the eye space...
+    // ...then to the eye space...
     transform_point(out, out, camera.Projection.Inverse);
 
     // ...and then to the world space.

--- a/core/components/com_camera2d.ts
+++ b/core/components/com_camera2d.ts
@@ -2,7 +2,7 @@
  * @module components/com_camera2d
  */
 
-import {create} from "../../common/mat2d.js";
+import {create, transform_point} from "../../common/mat2d.js";
 import {Mat2D, Vec2} from "../../common/math.js";
 import {Projection2D} from "../../common/projection2d.js";
 import {Entity} from "../../common/world.js";
@@ -12,7 +12,8 @@ import {Has} from "../world.js";
 export interface Camera2D {
     Projection: Projection2D;
     Pv: Mat2D;
-    Position: Vec2;
+    World: Mat2D;
+    ViewportSize: Vec2;
 }
 
 export function camera2d(radius: Vec2) {
@@ -25,7 +26,20 @@ export function camera2d(radius: Vec2) {
                 Inverse: [radius[0], 0, 0, radius[1], 0, 0],
             },
             Pv: create(),
-            Position: [0, 0],
+            World: create(),
+            ViewportSize: [0, 0],
         };
     };
+}
+
+export function viewport_to_world(out: Vec2, camera: Camera2D, pos: Vec2) {
+    // Transform the position from viewport space to NDC space (where +Y is up).
+    out[0] = (pos[0] / camera.ViewportSize[0]) * 2 - 1;
+    out[1] = -(pos[1] / camera.ViewportSize[1]) * 2 + 1;
+
+    // ...then the eye space...
+    transform_point(out, out, camera.Projection.Inverse);
+
+    // ...and then to the world space.
+    transform_point(out, out, camera.World);
 }

--- a/core/components/com_camera2d.ts
+++ b/core/components/com_camera2d.ts
@@ -1,0 +1,31 @@
+/**
+ * @module components/com_camera2d
+ */
+
+import {create} from "../../common/mat2d.js";
+import {Mat2D, Vec2} from "../../common/math.js";
+import {Projection2D} from "../../common/projection2d.js";
+import {Entity} from "../../common/world.js";
+import {Game} from "../game.js";
+import {Has} from "../world.js";
+
+export interface Camera2D {
+    Projection: Projection2D;
+    Pv: Mat2D;
+    Position: Vec2;
+}
+
+export function camera2d(radius: Vec2) {
+    return (game: Game, entity: Entity) => {
+        game.World.Signature[entity] |= Has.Camera2D;
+        game.World.Camera2D[entity] = {
+            Projection: {
+                Radius: radius,
+                Projection: [1 / radius[0], 0, 0, 1 / radius[1], 0, 0],
+                Inverse: [radius[0], 0, 0, radius[1], 0, 0],
+            },
+            Pv: create(),
+            Position: [0, 0],
+        };
+    };
+}

--- a/core/components/com_camera2d.ts
+++ b/core/components/com_camera2d.ts
@@ -18,6 +18,20 @@ export interface Camera2D {
     ViewportHeight: number;
 }
 
+/**
+ * Add Camera2D to an entity.
+ *
+ * Camera2D always uses an orthographic projection. The projection is set up
+ * with z-order +1 as the near plane and -1 as the far plane. Use render2d's
+ * order() mixin to change the z-order.
+ *
+ * The radius of the projection specifies how much of the world is visible
+ * min(horizontally, vertically), depending on the aspect ratio.  As a special
+ * case, if the radius is [0, 0], sys_resize2d will dynamically resize the
+ * projection to keep the unit size in pixels constant.
+ *
+ * @param radius The radius of the projection: [left, top].
+ */
 export function camera2d(radius: Vec2) {
     return (game: Game, entity: Entity) => {
         game.World.Signature[entity] |= Has.Camera2D;

--- a/core/components/com_camera2d.ts
+++ b/core/components/com_camera2d.ts
@@ -2,9 +2,10 @@
  * @module components/com_camera2d
  */
 
-import {create, transform_point} from "../../common/mat2d.js";
+import {create} from "../../common/mat2d.js";
 import {Mat2D, Vec2} from "../../common/math.js";
 import {Projection2D} from "../../common/projection2d.js";
+import {transform_position} from "../../common/vec2.js";
 import {Entity} from "../../common/world.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
@@ -40,8 +41,8 @@ export function viewport_to_world(out: Vec2, camera: Camera2D, pos: Vec2) {
     out[1] = -(pos[1] / camera.ViewportHeight) * 2 + 1;
 
     // ...then to the eye space...
-    transform_point(out, out, camera.Projection.Inverse);
+    transform_position(out, out, camera.Projection.Inverse);
 
     // ...and then to the world space.
-    transform_point(out, out, camera.World);
+    transform_position(out, out, camera.World);
 }

--- a/core/components/com_render2d.ts
+++ b/core/components/com_render2d.ts
@@ -1,4 +1,5 @@
 import {Vec4} from "../../common/math.js";
+import {clamp} from "../../common/number.js";
 import {Entity} from "../../common/world.js";
 import {FLOATS_PER_INSTANCE} from "../../materials/layout2d.js";
 import {spritesheet} from "../../sprites/spritesheet.js";
@@ -11,6 +12,14 @@ export interface Render2D {
     Sprite: Float32Array;
 }
 
+/**
+ * Add Render2D to an entity.
+ *
+ * By default, the z-order is 0. Use the order() mixin to change it.
+ *
+ * @param sprite_name The name of the sprite to render.
+ * @param color The tint of the sprite.
+ */
 export function render2d(sprite_name: string, color: Vec4 = [1, 1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         let instance_offset = entity * FLOATS_PER_INSTANCE;
@@ -37,10 +46,20 @@ export function render2d(sprite_name: string, color: Vec4 = [1, 1, 1, 1]) {
     };
 }
 
+/**
+ * Set the z-order of an entity.
+ *
+ * Camera2D's projection is set up with z-order +1 as the near plane and -1 as
+ * the far plane. The z-order set by this mixin is clamped to the [-1, 1] range.
+ * If you want to skip the sprite while rendering, remove Has.Render2D from its
+ * signature.
+ *
+ * @param z The z-order of the sprite, clamped to [-1, 1].
+ */
 export function order(z: number) {
     return (game: Game, entity: Entity) => {
         let instance_offset = entity * FLOATS_PER_INSTANCE;
-        game.InstanceData[instance_offset + 6] = z;
+        game.InstanceData[instance_offset + 6] = clamp(-1, 1, z);
     };
 }
 

--- a/core/components/com_render2d.ts
+++ b/core/components/com_render2d.ts
@@ -1,5 +1,4 @@
 import {Vec4} from "../../common/math.js";
-import {map_range} from "../../common/number.js";
 import {Entity} from "../../common/world.js";
 import {FLOATS_PER_INSTANCE} from "../../materials/layout2d.js";
 import {spritesheet} from "../../sprites/spritesheet.js";
@@ -16,9 +15,8 @@ export function render2d(sprite_name: string, color: Vec4 = [1, 1, 1, 1]) {
     return (game: Game, entity: Entity) => {
         let instance_offset = entity * FLOATS_PER_INSTANCE;
         // Detail.
-        // Place entities from closest to the farthest away to avoid overdraw.
-        game.InstanceData[instance_offset + 6] = map_range(entity, 0, game.World.Capacity, 1, 0);
-        game.InstanceData[instance_offset + 7] = Has.Render2D;
+        game.InstanceData[instance_offset + 6] = 0; // z-order.
+        game.InstanceData[instance_offset + 7] = Has.Render2D; // signature.
         // Color.
         game.InstanceData[instance_offset + 8] = color[0];
         game.InstanceData[instance_offset + 9] = color[1];

--- a/core/components/com_render2d.ts
+++ b/core/components/com_render2d.ts
@@ -18,7 +18,7 @@ export function render2d(sprite_name: string, color: Vec4 = [1, 1, 1, 1]) {
         // Detail.
         // Place entities from closest to the farthest away to avoid overdraw.
         game.InstanceData[instance_offset + 6] = map_range(entity, 0, game.World.Capacity, 1, 0);
-        game.InstanceData[instance_offset + 7] = 1; // Has.Render2D
+        game.InstanceData[instance_offset + 7] = Has.Render2D;
         // Color.
         game.InstanceData[instance_offset + 8] = color[0];
         game.InstanceData[instance_offset + 9] = color[1];

--- a/core/systems/sys_camera.ts
+++ b/core/systems/sys_camera.ts
@@ -13,14 +13,14 @@ const QUERY = Has.Transform | Has.Camera;
 export function sys_camera(game: Game, delta: number) {
     game.Cameras = [];
 
-    for (let i = 0; i < game.World.Signature.length; i++) {
-        if ((game.World.Signature[i] & QUERY) === QUERY) {
-            let camera = game.World.Camera[i];
+    for (let ent = 0; ent < game.World.Signature.length; ent++) {
+        if ((game.World.Signature[ent] & QUERY) === QUERY) {
+            let camera = game.World.Camera[ent];
             switch (camera.Kind) {
                 case CameraKind.Canvas:
                 case CameraKind.Target:
-                    update_camera(game, i, camera);
-                    game.Cameras.push(i);
+                    update_camera(game, ent, camera);
+                    game.Cameras.push(ent);
                     break;
             }
         }

--- a/core/systems/sys_camera.ts
+++ b/core/systems/sys_camera.ts
@@ -2,9 +2,9 @@
  * @module systems/sys_camera
  */
 
-import {get_translation, multiply} from "../../common/mat4.js";
+import {copy, get_translation, multiply} from "../../common/mat4.js";
 import {Entity} from "../../common/world.js";
-import {Camera, CameraKind, CameraXr} from "../components/com_camera.js";
+import {CameraCanvas, CameraKind, CameraTarget} from "../components/com_camera.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
 
@@ -16,6 +16,9 @@ export function sys_camera(game: Game, delta: number) {
     for (let ent = 0; ent < game.World.Signature.length; ent++) {
         if ((game.World.Signature[ent] & QUERY) === QUERY) {
             let camera = game.World.Camera[ent];
+            let transform = game.World.Transform[ent];
+            copy(camera.World, transform.World);
+
             switch (camera.Kind) {
                 case CameraKind.Canvas:
                 case CameraKind.Target:
@@ -27,7 +30,7 @@ export function sys_camera(game: Game, delta: number) {
     }
 }
 
-function update_camera(game: Game, entity: Entity, camera: Exclude<Camera, CameraXr>) {
+function update_camera(game: Game, entity: Entity, camera: CameraCanvas | CameraTarget) {
     let transform = game.World.Transform[entity];
     let projection = camera.Projection;
 

--- a/core/systems/sys_camera.ts
+++ b/core/systems/sys_camera.ts
@@ -2,7 +2,7 @@
  * @module systems/sys_camera
  */
 
-import {copy, get_translation, multiply} from "../../common/mat4.js";
+import {get_translation, multiply} from "../../common/mat4.js";
 import {Entity} from "../../common/world.js";
 import {Camera, CameraKind, CameraXr} from "../components/com_camera.js";
 import {Game} from "../game.js";
@@ -31,7 +31,6 @@ function update_camera(game: Game, entity: Entity, camera: Exclude<Camera, Camer
     let transform = game.World.Transform[entity];
     let projection = camera.Projection;
 
-    copy(camera.View, transform.Self);
-    multiply(camera.Pv, projection.Projection, camera.View);
+    multiply(camera.Pv, projection.Projection, transform.Self);
     get_translation(camera.Position, transform.World);
 }

--- a/core/systems/sys_camera2d.ts
+++ b/core/systems/sys_camera2d.ts
@@ -2,7 +2,7 @@
  * @module systems/sys_camera2d
  */
 
-import {multiply} from "../../common/mat2d.js";
+import {copy, multiply} from "../../common/mat2d.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
 
@@ -17,8 +17,9 @@ export function sys_camera2d(game: Game, delta: number) {
             let camera_node = game.World.SpatialNode2D[ent];
 
             multiply(camera.Pv, camera.Projection.Projection, camera_node.Self);
-            camera.Position[0] = camera_node.World[4];
-            camera.Position[1] = camera_node.World[5];
+            copy(camera.World, camera_node.World);
+            camera.ViewportSize[0] = game.ViewportWidth;
+            camera.ViewportSize[1] = game.ViewportHeight;
 
             game.Cameras.push(ent);
         }

--- a/core/systems/sys_camera2d.ts
+++ b/core/systems/sys_camera2d.ts
@@ -1,42 +1,24 @@
 /**
- * @module systems/sys_camera
+ * @module systems/sys_camera2d
  */
 
-import {multiply} from "../../common/mat4.js";
-import {CameraKind} from "../components/com_camera.js";
+import {multiply} from "../../common/mat2d.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
 
-const QUERY = Has.SpatialNode2D | Has.Camera;
-
-// The camera is hardcoded at z=2, with near=1 and far=3.
-const CAMERA_Z = 2;
+const QUERY = Has.SpatialNode2D | Has.Camera2D;
 
 export function sys_camera2d(game: Game, delta: number) {
     game.Cameras = [];
 
     for (let ent = 0; ent < game.World.Signature.length; ent++) {
         if ((game.World.Signature[ent] & QUERY) === QUERY) {
-            let camera = game.World.Camera[ent];
-            if (camera.Kind !== CameraKind.Canvas) {
-                throw new Error("Only canvas cameras are supported.");
-            }
-
-            let projection = camera.Projection;
+            let camera = game.World.Camera2D[ent];
             let camera_node = game.World.SpatialNode2D[ent];
 
-            camera.View[0] = camera_node.Self[0];
-            camera.View[1] = camera_node.Self[1];
-            camera.View[4] = camera_node.Self[2];
-            camera.View[5] = camera_node.Self[3];
-            camera.View[12] = camera_node.Self[4];
-            camera.View[13] = camera_node.Self[5];
-            camera.View[14] = -CAMERA_Z;
-
-            multiply(camera.Pv, projection.Projection, camera.View);
+            multiply(camera.Pv, camera.Projection.Projection, camera_node.Self);
             camera.Position[0] = camera_node.World[4];
             camera.Position[1] = camera_node.World[5];
-            camera.Position[2] = CAMERA_Z;
 
             game.Cameras.push(ent);
         }

--- a/core/systems/sys_camera2d.ts
+++ b/core/systems/sys_camera2d.ts
@@ -18,8 +18,6 @@ export function sys_camera2d(game: Game, delta: number) {
 
             multiply(camera.Pv, camera.Projection.Projection, camera_node.Self);
             copy(camera.World, camera_node.World);
-            camera.ViewportSize[0] = game.ViewportWidth;
-            camera.ViewportSize[1] = game.ViewportHeight;
 
             game.Cameras.push(ent);
         }

--- a/core/systems/sys_camera_xr.ts
+++ b/core/systems/sys_camera_xr.ts
@@ -34,7 +34,6 @@ function update_xr(game: Game, entity: Entity, camera: CameraXr) {
     for (let viewpoint of pose.views) {
         let eye: XrEye = {
             Viewpoint: viewpoint,
-            View: create(),
             Pv: create(),
             Position: [0, 0, 0],
             FogColor: camera.ClearColor,
@@ -42,13 +41,13 @@ function update_xr(game: Game, entity: Entity, camera: CameraXr) {
         };
 
         // Compute the eye's world matrix.
-        multiply(eye.View, transform.World, viewpoint.transform.matrix);
-        get_translation(eye.Position, eye.View);
+        multiply(eye.Pv /* world */, transform.World, viewpoint.transform.matrix);
+        get_translation(eye.Position, eye.Pv /* world */);
 
         // Compute the view matrix.
-        invert(eye.View, eye.View);
+        invert(eye.Pv /* view */, eye.Pv /* world */);
         // Compute the PV matrix.
-        multiply(eye.Pv, viewpoint.projectionMatrix, eye.View);
+        multiply(eye.Pv, viewpoint.projectionMatrix, eye.Pv /* view */);
 
         camera.Eyes.push(eye);
     }

--- a/core/systems/sys_draw2d.ts
+++ b/core/systems/sys_draw2d.ts
@@ -2,7 +2,6 @@
  * @module systems/sys_draw2d
  */
 
-import {CameraKind} from "../components/com_camera.js";
 import {DrawKind} from "../components/com_draw.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
@@ -15,10 +14,7 @@ export function sys_draw2d(game: Game, delta: number) {
         return;
     }
 
-    let camera = game.World.Camera[camera_entity];
-    if (camera.Kind === CameraKind.Xr) {
-        throw new Error("XR not implemented");
-    }
+    let camera = game.World.Camera2D[camera_entity];
 
     let ctx = game.Context2D;
     ctx.resetTransform();
@@ -28,10 +24,10 @@ export function sys_draw2d(game: Game, delta: number) {
     ctx.transform(
         (camera.Pv[0] / 2) * game.ViewportWidth,
         -(camera.Pv[1] / 2) * game.ViewportWidth,
-        -(camera.Pv[4] / 2) * game.ViewportHeight,
-        (camera.Pv[5] / 2) * game.ViewportHeight,
-        ((camera.Pv[12] + 1) / 2) * game.ViewportWidth,
-        ((camera.Pv[13] + 1) / 2) * game.ViewportHeight
+        -(camera.Pv[2] / 2) * game.ViewportHeight,
+        (camera.Pv[3] / 2) * game.ViewportHeight,
+        ((camera.Pv[4] + 1) / 2) * game.ViewportWidth,
+        ((camera.Pv[5] + 1) / 2) * game.ViewportHeight
     );
 
     for (let ent = 0; ent < game.World.Signature.length; ent++) {

--- a/core/systems/sys_draw2d.ts
+++ b/core/systems/sys_draw2d.ts
@@ -27,8 +27,8 @@ export function sys_draw2d(game: Game, delta: number) {
 
     ctx.transform(
         (camera.Pv[0] / 2) * game.ViewportWidth,
-        (camera.Pv[1] / 2) * game.ViewportWidth,
-        (camera.Pv[4] / 2) * game.ViewportHeight,
+        -(camera.Pv[1] / 2) * game.ViewportWidth,
+        -(camera.Pv[4] / 2) * game.ViewportHeight,
         (camera.Pv[5] / 2) * game.ViewportHeight,
         ((camera.Pv[12] + 1) / 2) * game.ViewportWidth,
         ((camera.Pv[13] + 1) / 2) * game.ViewportHeight

--- a/core/systems/sys_render2d.ts
+++ b/core/systems/sys_render2d.ts
@@ -1,12 +1,14 @@
 import {
     GL_ARRAY_BUFFER,
+    GL_COLOR_BUFFER_BIT,
+    GL_DEPTH_BUFFER_BIT,
     GL_FRAMEBUFFER,
     GL_STREAM_DRAW,
     GL_TEXTURE0,
     GL_TEXTURE_2D,
 } from "../../common/webgl.js";
 import {FLOATS_PER_INSTANCE} from "../../materials/layout2d.js";
-import {CameraEye, CameraKind} from "../components/com_camera.js";
+import {Camera2D} from "../components/com_camera2d.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
 
@@ -21,25 +23,21 @@ export function sys_render2d(game: Game, delta: number) {
     }
 
     for (let camera_entity of game.Cameras) {
-        let camera = game.World.Camera[camera_entity];
-        switch (camera.Kind) {
-            case CameraKind.Canvas:
-                game.Gl.bindFramebuffer(GL_FRAMEBUFFER, null);
-                game.Gl.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
-                game.Gl.clearColor(...camera.ClearColor);
-                game.Gl.clear(camera.ClearMask);
-                render_all(game, camera);
-                break;
-        }
+        let camera = game.World.Camera2D[camera_entity];
+        game.Gl.bindFramebuffer(GL_FRAMEBUFFER, null);
+        game.Gl.viewport(0, 0, game.ViewportWidth, game.ViewportHeight);
+        game.Gl.clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        render_all(game, camera);
+        break;
     }
 }
 
-function render_all(game: Game, eye: CameraEye) {
+function render_all(game: Game, eye: Camera2D) {
     let material = game.MaterialInstanced;
     let sheet = game.Spritesheet;
 
     game.Gl.useProgram(material.Program);
-    game.Gl.uniformMatrix4fv(material.Locations.Pv, false, eye.Pv);
+    game.Gl.uniformMatrix3x2fv(material.Locations.Pv, false, eye.Pv);
 
     game.Gl.activeTexture(GL_TEXTURE0);
     game.Gl.bindTexture(GL_TEXTURE_2D, sheet.Texture);

--- a/core/systems/sys_resize.ts
+++ b/core/systems/sys_resize.ts
@@ -8,12 +8,8 @@ import {
     resize_hdr_target,
     TargetKind,
 } from "../../common/framebuffer.js";
-import {
-    Projection,
-    ProjectionKind,
-    resize_ortho,
-    resize_perspective,
-} from "../../common/projection.js";
+import {from_ortho, from_perspective, invert} from "../../common/mat4.js";
+import {Projection, ProjectionKind} from "../../common/projection.js";
 import {CameraKind} from "../components/com_camera.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
@@ -83,11 +79,54 @@ export function sys_resize(game: Game, delta: number) {
 function update_projection(projection: Projection, aspect: number) {
     switch (projection.Kind) {
         case ProjectionKind.Perspective: {
-            resize_perspective(projection, aspect);
+            if (aspect < 1) {
+                // Portrait orientation.
+                from_perspective(
+                    projection.Projection,
+                    projection.FovY / aspect,
+                    aspect,
+                    projection.Near,
+                    projection.Far
+                );
+            } else {
+                // Landscape orientation.
+                from_perspective(
+                    projection.Projection,
+                    projection.FovY,
+                    aspect,
+                    projection.Near,
+                    projection.Far
+                );
+            }
             break;
         }
         case ProjectionKind.Orthographic:
-            resize_ortho(projection, aspect);
+            let target_aspect = projection.Radius[0] / projection.Radius[1];
+            if (aspect < target_aspect) {
+                // Portrait orientation.
+                from_ortho(
+                    projection.Projection,
+                    projection.Radius[0] / aspect,
+                    projection.Radius[0],
+                    -projection.Radius[0] / aspect,
+                    -projection.Radius[0],
+                    projection.Near,
+                    projection.Far
+                );
+            } else {
+                // Landscape orientation.
+                from_ortho(
+                    projection.Projection,
+                    projection.Radius[1],
+                    projection.Radius[1] * aspect,
+                    -projection.Radius[1],
+                    -projection.Radius[1] * aspect,
+                    projection.Near,
+                    projection.Far
+                );
+            }
             break;
     }
+
+    invert(projection.Inverse, projection.Projection);
 }

--- a/core/systems/sys_resize.ts
+++ b/core/systems/sys_resize.ts
@@ -64,6 +64,8 @@ export function sys_resize(game: Game, delta: number) {
                         );
                         break;
                     case CameraKind.Target:
+                        camera.ViewportWidth = game.ViewportWidth;
+                        camera.ViewportHeight = game.ViewportHeight;
                         update_projection(
                             camera.Projection,
                             camera.Target.Width / camera.Target.Height

--- a/core/systems/sys_resize.ts
+++ b/core/systems/sys_resize.ts
@@ -56,6 +56,8 @@ export function sys_resize(game: Game, delta: number) {
                 let camera = game.World.Camera[i];
                 switch (camera.Kind) {
                     case CameraKind.Canvas:
+                        camera.ViewportWidth = game.ViewportWidth;
+                        camera.ViewportHeight = game.ViewportHeight;
                         update_projection(
                             camera.Projection,
                             game.ViewportWidth / game.ViewportHeight

--- a/core/systems/sys_resize2d.ts
+++ b/core/systems/sys_resize2d.ts
@@ -2,12 +2,13 @@
  * @module systems/sys_resize2d
  */
 
-import {ProjectionKind, resize_ortho, resize_ortho_constant} from "../../common/projection.js";
-import {CameraKind} from "../components/com_camera.js";
+import {invert} from "../../common/mat2d.js";
+import {from_ortho} from "../../common/projection2d.js";
+import {Entity} from "../../common/world.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";
 
-const QUERY = Has.Camera;
+const QUERY = Has.Camera2D;
 const UNIT_PX = 32;
 
 export function sys_resize2d(game: Game, delta: number) {
@@ -21,23 +22,35 @@ export function sys_resize2d(game: Game, delta: number) {
 
         for (let ent = 0; ent < game.World.Signature.length; ent++) {
             if ((game.World.Signature[ent] & QUERY) === QUERY) {
-                let camera = game.World.Camera[ent];
-                if (
-                    camera.Kind == CameraKind.Canvas &&
-                    camera.Projection.Kind == ProjectionKind.Orthographic
-                ) {
-                    let aspect = game.ViewportWidth / game.ViewportHeight;
-                    if (camera.Projection.Radius[0] === 0 && camera.Projection.Radius[1] === 0) {
-                        // A special case for projections which dynamically
-                        // resize to keep the unit size in pixels constant.
-                        let radius = game.ViewportHeight / UNIT_PX / 2;
-                        resize_ortho_constant(camera.Projection, radius, aspect);
-                    } else {
-                        resize_ortho(camera.Projection, aspect);
-                    }
-                    break;
-                }
+                update(game, ent);
             }
         }
     }
+}
+
+function update(game: Game, entity: Entity) {
+    let camera = game.World.Camera2D[entity];
+
+    let projection = camera.Projection;
+    let aspect = game.ViewportWidth / game.ViewportHeight;
+    if (projection.Radius[0] === 0 && projection.Radius[1] === 0) {
+        // A special case for projections which dynamically resize to keep the
+        // unit size in pixels constant. Ignore projection.Radius and instead
+        // apply a radius computed taking into account the world unit size in
+        // pixels. This is useful for keeping the unit size constant across
+        // different viewport dimensions, and help pixel art sprites look crisp.
+        let radius = game.ViewportHeight / UNIT_PX / 2;
+        from_ortho(projection.Inverse, radius * aspect, radius);
+    } else {
+        let target_aspect = projection.Radius[0] / projection.Radius[1];
+        if (aspect < target_aspect) {
+            // Portrait orientation.
+            from_ortho(projection.Inverse, projection.Radius[0], projection.Radius[0] / aspect);
+        } else {
+            // Landscape orientation.
+            from_ortho(projection.Inverse, projection.Radius[1] * aspect, projection.Radius[1]);
+        }
+    }
+
+    invert(projection.Projection, projection.Inverse);
 }

--- a/core/systems/sys_resize2d.ts
+++ b/core/systems/sys_resize2d.ts
@@ -2,8 +2,7 @@
  * @module systems/sys_resize2d
  */
 
-import {invert} from "../../common/mat2d.js";
-import {from_ortho} from "../../common/projection2d.js";
+import {from_ortho, invert} from "../../common/mat2d.js";
 import {Entity} from "../../common/world.js";
 import {Game} from "../game.js";
 import {Has} from "../world.js";

--- a/core/systems/sys_resize2d.ts
+++ b/core/systems/sys_resize2d.ts
@@ -30,6 +30,9 @@ export function sys_resize2d(game: Game, delta: number) {
 function update(game: Game, entity: Entity) {
     let camera = game.World.Camera2D[entity];
 
+    camera.ViewportWidth = game.ViewportWidth;
+    camera.ViewportHeight = game.ViewportHeight;
+
     let projection = camera.Projection;
     let aspect = game.ViewportWidth / game.ViewportHeight;
     if (projection.Radius[0] === 0 && projection.Radius[1] === 0) {

--- a/core/world.ts
+++ b/core/world.ts
@@ -3,6 +3,7 @@ import {Animate} from "./components/com_animate.js";
 import {AnimateSprite} from "./components/com_animate_sprite.js";
 import {AudioSource} from "./components/com_audio_source.js";
 import {Camera} from "./components/com_camera.js";
+import {Camera2D} from "./components/com_camera2d.js";
 import {Children} from "./components/com_children.js";
 import {Collide} from "./components/com_collide.js";
 import {ControlAlways} from "./components/com_control_always.js";
@@ -36,6 +37,7 @@ const enum Component {
     AudioListener,
     AudioSource,
     Camera,
+    Camera2D,
     Children,
     Collide,
     ControlAlways,
@@ -73,6 +75,7 @@ export const enum Has {
     AudioListener = 1 << Component.AudioListener,
     AudioSource = 1 << Component.AudioSource,
     Camera = 1 << Component.Camera,
+    Camera2D = 1 << Component.Camera2D,
     Children = 1 << Component.Children,
     Collide = 1 << Component.Collide,
     ControlAlways = 1 << Component.ControlAlways,
@@ -108,6 +111,7 @@ export interface World extends WorldImpl {
     AnimateSprite: Array<AnimateSprite>;
     AudioSource: Array<AudioSource>;
     Camera: Array<Camera>;
+    Camera2D: Array<Camera2D>;
     Children: Array<Children>;
     Collide: Array<Collide>;
     ControlAlways: Array<ControlAlways>;

--- a/materials/layout2d.ts
+++ b/materials/layout2d.ts
@@ -25,19 +25,19 @@ export function setup_render2d_buffers(gl: WebGL2RenderingContext, instance_buff
     // with spritesheet map coordinates.
     // prettier-ignore
     let vertex_arr = Float32Array.from([
-        -0.5, -0.5, 1,    0, 1,    // SW
-        0.5, -0.5, 1,     1, 1,    // SE
-        -0.5, 0.5, 1,     0, 0,    // NW
-        0.5, 0.5, 1,      1, 0     // NE
+        -0.5, -0.5,    0, 1,    // SW
+        0.5, -0.5,     1, 1,    // SE
+        -0.5, 0.5,     0, 0,    // NW
+        0.5, 0.5,      1, 0     // NE
     ]);
 
     // Vertex positions and texture coordinates.
     gl.bindBuffer(GL_ARRAY_BUFFER, gl.createBuffer()!);
     gl.bufferData(GL_ARRAY_BUFFER, vertex_arr, GL_STATIC_DRAW);
     gl.enableVertexAttribArray(Attribute.VertexPosition);
-    gl.vertexAttribPointer(Attribute.VertexPosition, 3, GL_FLOAT, false, 4 * 5, 0);
+    gl.vertexAttribPointer(Attribute.VertexPosition, 2, GL_FLOAT, false, 4 * 4, 0);
     gl.enableVertexAttribArray(Attribute.VertexTexCoord);
-    gl.vertexAttribPointer(Attribute.VertexTexCoord, 2, GL_FLOAT, false, 4 * 5, 4 * 3);
+    gl.vertexAttribPointer(Attribute.VertexTexCoord, 2, GL_FLOAT, false, 4 * 4, 4 * 2);
 
     // Instance data.
     gl.bindBuffer(GL_ARRAY_BUFFER, instance_buffer);

--- a/materials/layout2d.ts
+++ b/materials/layout2d.ts
@@ -25,10 +25,10 @@ export function setup_render2d_buffers(gl: WebGL2RenderingContext, instance_buff
     // with spritesheet map coordinates.
     // prettier-ignore
     let vertex_arr = Float32Array.from([
-        -0.5, -0.5, 0,    0, 1,    // SW
-        0.5, -0.5, 0,     1, 1,    // SE
-        -0.5, 0.5, 0,     0, 0,    // NW
-        0.5, 0.5, 0,      1, 0     // NE
+        -0.5, -0.5, 1,    0, 1,    // SW
+        0.5, -0.5, 1,     1, 1,    // SE
+        -0.5, 0.5, 1,     0, 0,    // NW
+        0.5, 0.5, 1,      1, 0     // NE
     ]);
 
     // Vertex positions and texture coordinates.

--- a/sprites/spritesheet.ts
+++ b/sprites/spritesheet.ts
@@ -1,3 +1,4 @@
+// prettier-ignore
 export let spritesheet: {
     [key: string]: {
         x: number;

--- a/sprites/spritesmith.cjs
+++ b/sprites/spritesmith.cjs
@@ -21,7 +21,8 @@ Spritesmith.run(
 
         writeFileSync(__dirname + "/" + sheet, result.image);
         console.log(
-            `export let spritesheet: {
+            `// prettier-ignore
+export let spritesheet: {
     [key: string]: {
         x: number;
         y: number;


### PR DESCRIPTION
This allows to stop using Mat4 functions (multiply, inverse).

- (sys_draw2d) Invert the direction of eye.Pv's rotation
- Camera2D, Projection2D
- The sprite quad doesn't define Z
- +Z is towards the user
- Inline resize_perspective, resize_ortho
- viewpoer_to_world
- CameraCanvas.ViewportWidth, ViewportHeight
- Remove CameraEye.View
- viewport_to_world in 3D
- Remove mat2d's transform_point, which duplicated vec2's transform_position
